### PR TITLE
Extract a specific axis via ax = A[Axis{:t}]

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -202,3 +202,9 @@ end
     meta = Expr(:meta, :inline)
     return :($meta; $ex)
 end
+
+## Extracting the full axis (name + values) from the Axis{:name} type
+@inline Base.getindex{Ax<:Axis}(A::AxisArray, ::Type{Ax}) = getaxis(Ax, axes(A)...)
+@inline getaxis{Ax<:Axis}(::Type{Ax}, ax::Ax, axs...) = ax
+@inline getaxis{Ax<:Axis}(::Type{Ax}, ax::Axis, axs...) = getaxis(Ax, axs...)
+@noinline getaxis{Ax<:Axis}(::Type{Ax}) = throw(ArgumentError("no axis of type $Ax was found"))

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -95,3 +95,12 @@ A = AxisArray(reshape(1:15, 3, 5), :x, :y)
 @test A[2,2,CartesianIndex(())] == 5
 @test A[2,CartesianIndex(()),2] == 5
 @test A[CartesianIndex(()),2,2] == 5
+
+# Extracting the full axis
+axx = @inferred(A[Axis{:x}])
+@test isa(axx, Axis{:x})
+@test axx.val == 1:3
+axy = @inferred(A[Axis{:y}])
+@test isa(axy, Axis{:y})
+@test axy.val == 1:5
+@test_throws ArgumentError A[Axis{:z}]


### PR DESCRIPTION
Surprisingly, we still haven't exhausted the number of ways one can combine indexing operations in interesting ways. Here's what I think is a new one:
```jl
julia> using AxisArrays

julia> A = AxisArray(reshape(1:15, 3, 5), :x, :y)
2-dimensional AxisArray{Int64,2,...} with axes:
    :x, Base.OneTo(3)
    :y, Base.OneTo(5)
And data, a 3×5 Base.ReshapedArray{Int64,2,UnitRange{Int64},Tuple{}}:
 1  4  7  10  13
 2  5  8  11  14
 3  6  9  12  15

julia> axx = A[Axis{:x}]
AxisArrays.Axis{:x,Base.OneTo{Int64}}(Base.OneTo(3))
```

If there's already another way to get the full axis-instance in an inferrable fashion, do let me know. (One that isn't is
```jl
foo{Ax}(A, ::Type{Ax}) = A.axes[axisdim(A, Ax)]
```
)