### PR TITLE
Make `axes` provide defaults for AbstractArray

### DIFF
--- a/test/core.jl
+++ b/test/core.jl
@@ -138,6 +138,10 @@ A = AxisArray(reshape(1:24, 2,3,4),
 @test @inferred(axes(A, Axis{:y})) == @inferred(axes(A, Axis{:y}())) == Axis{:y}(1//10:1//10:3//10)
 @test @inferred(axes(A, Axis{:z})) == @inferred(axes(A, Axis{:z}())) == Axis{:z}(["a", "b", "c", "d"])
 @test axes(A, 2) == Axis{:y}(1//10:1//10:3//10)
+Aplain = rand(2,3)
+@test @inferred(axes(Aplain)) === axes(AxisArray(Aplain))
+@test axes(Aplain, 1) === axes(AxisArray(Aplain))[1]
+@test axes(Aplain, 2) === axes(AxisArray(Aplain))[2]
 
 @test Axis{:col}(1) == Axis{:col}(1)
 @test Axis{:col}(1) != Axis{:com}(1)


### PR DESCRIPTION
This is a bit speculative and perhaps too dicey, but I thought I'd inquire:
```jl
julia> using AxisArrays

julia> axes(rand(3,5))
(Base.OneTo(3),Base.OneTo(5))
```
The motivation is the following: the [ImageMetadata](https://github.com/JuliaImages/ImageMetadata.jl) package defines the successor to the old `Image` type (array + dict) in Images.jl.  When the array inside the `ImageMeta` is an `AxisArray`, it would be nice to give it AxisArray-like properties. However, using that capability "safely" currently requires dispatch:
```jl
foo(A::AbstractArray) = # default action, don't call axes
foo(A::AxisArray) = axes(A)[2]
foo(A::ImageMetaAxis) = axes(data(A))[2]
```
That makes `ImageMetadata` a required package whenever I'd like `foo` to "do the right thing." I'm not thrilled about requiring it everywhere, since I'm trying to de-emphasize the dict in favor of leveraging the type system (aka, use AxisArrays to do almost all the old stuff the dict used to do).

The alternative is to make `axes` safe for use on any array type, with a sensible fallback when there is no axis information to return. Since `Axis` is kind of like a range (at least, as returned by `axes(A)`), it seems that `indices` is the obvious fallback.

The down side is that `axes` does sort of imply that it should return Axis information. So I will fully understand if you don't like this.
