### PR TITLE
Test and fix the code in the README

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -38,8 +38,15 @@ end
 
 if VERSION > v"0.5.0-dev+4557"
     # When running with "--check-bounds=yes" (like on Travis), the bounds-check isn't elided
+    @inline function Base.unsafe_getindex{T}(v::Range{T}, i::Integer)
+        convert(T, first(v) + (i-1)*step(v))
+    end
     @inline function Base.unsafe_getindex{T}(r::FloatRange{T}, i::Integer)
         convert(T, (r.start + (i-1)*r.step)/r.divisor)
+    end
+    @inline function Base.unsafe_getindex{T<:Integer}(r::StepRange, s::Range{T})
+        st = oftype(r.start, r.start + (first(s)-1)*step(r))
+        range(st, step(r)*step(s), length(s))
     end
     @inline function Base.unsafe_getindex(r::FloatRange, s::OrdinalRange)
         FloatRange(r.start + (first(s)-1)*r.step, step(s)*r.step, length(s), r.divisor)

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 OffsetArrays
+SIUnits

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -1,0 +1,53 @@
+# Intended to ensure the README stays working (this is a copy)
+
+using AxisArrays, SIUnits
+import SIUnits.ShortUnits: s, ms, µs
+
+fs = 40000
+y = randn(60*fs+1)*3
+for spk = (sin(0.8:0.2:8.6) .* [0:0.01:.1; .15:.1:.95; 1:-.05:.05]   .* 50,
+           sin(0.8:0.4:8.6) .* [0:0.02:.1; .15:.1:1; 1:-.2:.1] .* 50)
+    i = rand(round(Int,.001fs):1fs)
+    while i+length(spk)-1 < length(y)
+        y[i:i+length(spk)-1] += spk
+        i += rand(round(Int,.001fs):1fs)
+    end
+end
+
+A = AxisArray([y 2y], Axis{:time}(0s:1s/fs:60s), Axis{:chan}([:c1, :c2]))
+A[Axis{:time}(4)]
+A[Axis{:chan}(:c2), Axis{:time}(1:5)]
+ax = A[40µs .. 220µs, :c1]
+axes(ax, 1)
+A[atindex(-90µs .. 90µs, 5), :c2]
+idxs = find(diff(A[:,:c1] .< -15) .> 0)
+spks = A[atindex(-200µs .. 800µs, idxs), :c1]
+
+
+# # A possible "dynamic verification" strategy
+# const readmefile = joinpath(dirname(dirname(@__FILE__)), "README.md")
+
+# function extract_julialines(iowr, filein)
+#     open(filein) do iord
+#         while !eof(iord)
+#             line = readline(iord)
+#             if startswith(line, "julia>")
+#                 print(iowr, line[8:end])
+#                 while !eof(iord)
+#                     line = readline(iord)
+#                     if !startswith(line, "    ")
+#                         break
+#                     end
+#                     print(iowr, line[8:end])
+#                 end
+#             end
+#         end
+#     end
+# end
+
+# tmpfile, iowr = mktemp()
+# extract_julialines(iowr, readmefile)
+# close(iowr)
+
+# include(tmpfile)
+# rm(tmpfile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,4 +10,6 @@ include("sortedvector.jl")
 include("search.jl")
 include("combine.jl")
 
+include("readme.jl")
+
 nothing


### PR DESCRIPTION
For #37. Good spotting that this needed doing.

~~The strategy I took was simply to unpack the Range operations directly. A little inelegant, perhaps, but avoids any risk that `unsafe_getindex` will complain.~~ ~~Won't pass tests without https://github.com/JuliaLang/METADATA.jl/pull/6665.~~

BTW, I am in the process of switching over to [Unitful](https://github.com/ajkeller34/Unitful.jl) for all my units needs. The main holdup is that Base's ranges aren't quite up to snuff, which is basically what my LinSpace PR is all about. See https://github.com/ajkeller34/Unitful.jl/pull/31.

(SIUnits does better in this regard because rolls its own Range type, as a wrapper around `FloatRange` and appending units. I tend to think that a better approach is to generalize the Base ranges so that they can work with unitful objects.)