### PR TITLE
Add HasAxes trait

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -193,6 +193,12 @@ AxisArray(A::AbstractArray) = AxisArray(A, ()) # Disambiguation
 AxisArray(A::AbstractArray, names::Symbol...)         = AxisArray(A, map((name,ind)->Axis{name}(ind), names, indices(A)))
 AxisArray(A::AbstractArray, vects::AbstractVector...) = AxisArray(A, ntuple(i->Axis{_defaultdimname(i)}(vects[i]), length(vects)))
 
+# Traits
+immutable HasAxes{B} end
+HasAxes{A<:AxisArray}(::Type{A}) = HasAxes{true}()
+HasAxes{A<:AbstractArray}(::Type{A}) = HasAxes{false}()
+HasAxes(A::AbstractArray) = HasAxes(typeof(A))
+
 # Axis definitions
 @doc """
     axisdim(::AxisArray, ::Axis) -> Int

--- a/test/core.jl
+++ b/test/core.jl
@@ -118,6 +118,9 @@ A = AxisArray([0]', :x, :y)
 @test axisnames(@inferred(squeeze(A, Axis{:y}))) == (:x,)
 @test axisnames(@inferred(squeeze(squeeze(A, Axis{:x}), Axis{:y}))) == ()
 
+@test AxisArrays.HasAxes(A)   == AxisArrays.HasAxes{true}()
+@test AxisArrays.HasAxes([1]) == AxisArrays.HasAxes{false}()
+
 # Test axisdim
 @test_throws ArgumentError AxisArray(reshape(1:24, 2,3,4),
                                      Axis{1}(.1:.1:.2),


### PR DESCRIPTION
The intended use of this trait is to facilitate extensions of the AxisArrays interface to other AbstractArrays. IMO this is a better approach to https://github.com/JuliaArrays/AxisArrays.jl/pull/45#issue-180968070.