### PR TITLE
Drop the Compat requirement

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
-julia 0.5-
+julia 0.5
 IntervalSets
 Iterators
-Compat
 RangeArrays

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -3,8 +3,7 @@ __precompile__()
 module AxisArrays
 
 using Base: tail
-using RangeArrays, Iterators, IntervalSets, Compat
-using Compat.view
+using RangeArrays, Iterators, IntervalSets
 
 export AxisArray, Axis, axisnames, axisvalues, axisdim, axes, atindex
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -52,8 +52,8 @@ immutable Axis{name,T}
     val::T
 end
 # Constructed exclusively through Axis{:symbol}(...) or Axis{1}(...)
-@compat (::Type{Axis{name}}){name,T}(I::T=()) = Axis{name,T}(I)
-@compat Base.:(==){name}(A::Axis{name}, B::Axis{name}) = A.val == B.val
+(::Type{Axis{name}}){name,T}(I::T=()) = Axis{name,T}(I)
+Base.:(==){name}(A::Axis{name}, B::Axis{name}) = A.val == B.val
 Base.hash{name}(A::Axis{name}, hx::UInt) = hash(A.val, hash(name, hx))
 axistype{name,T}(::Axis{name,T}) = T
 axistype{name,T}(::Type{Axis{name,T}}) = T
@@ -66,7 +66,7 @@ Base.size(A::Axis) = size(A.val)
 Base.indices(A::Axis) = indices(A.val)
 Base.indices(A::Axis, d) = indices(A.val, d)
 Base.length(A::Axis) = length(A.val)
-@compat (A::Axis{name}){name}(i) = Axis{name}(i)
+(A::Axis{name}){name}(i) = Axis{name}(i)
 Base.convert{name,T}(::Type{Axis{name,T}}, ax::Axis{name,T}) = ax
 Base.convert{name,T}(::Type{Axis{name,T}}, ax::Axis{name}) = Axis{name}(convert(T, ax.val))
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -171,7 +171,7 @@ A = AxisArray(vals, Axis{:Timestamp}(dt-Dates.Hour(2):Dates.Hour(1):dt+Dates.Hou
 @test A[dt, :].data == vals[3, :]
 
 # Simply run the display method to ensure no stupid errors
-@compat show(IOBuffer(),MIME("text/plain"),A)
+show(IOBuffer(),MIME("text/plain"),A)
 
 # With unconventional indices
 import OffsetArrays  # import rather than using because OffsetArrays has a deprecation for ..

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using AxisArrays
-using Base.Test, Compat
+using Base.Test
 
 @test isempty(detect_ambiguities(AxisArrays, Base, Core))
 


### PR DESCRIPTION
We don't need this anymore. Noticed by @tkelman.