### PR TITLE
to_index now throws an ArgumentException instead of an UndefVarError …

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -107,7 +107,9 @@ end
     idxs = Expr[:(Colon()) for d = 1:N]
     names = axisnames(A)
     for i=1:length(dims)
-        idxs[dims[i]] == :(Colon()) || return :(error("multiple indices provided on axis ", $(names[dims[i]])))
+        idxs[dims[i]] == :(Colon()) ||
+            return :(throw(ArgumentError(string("multiple indices provided ",
+                "on axis ", $(string(names[dims[i]]))))))
         idxs[dims[i]] = :(I[$i].val)
     end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -136,3 +136,8 @@ axy = @inferred(A[Axis{:y}])
 @test isa(axy, Axis{:y})
 @test axy.val == 1:5
 @test_throws ArgumentError A[Axis{:z}]
+
+# Test for the expected exception type given repeated axes
+A = AxisArray(rand(2,2), :x, :y)
+@test_throws ArgumentError A[Axis{:x}(1), Axis{:x}(1)]
+@test_throws ArgumentError A[Axis{:y}(1), Axis{:y}(1)]


### PR DESCRIPTION
…when given repeated axes.

There is [a TODO in indexing.jl](https://github.com/JuliaArrays/AxisArrays.jl/blob/a63fd44fb7e4dd5c6036a4d8a8892f5c515739df/src/indexing.jl#L104) asking whether or not AxisArrays should allow indexing with repeated axes. This PR does not make a decision about that, but on master the expected `ErrorException` is not thrown:

```
julia> using AxisArrays
INFO: Recompiling stale cache file /Users/ajkeller/.julia/lib/v0.5/AxisArrays.ji for module AxisArrays.

julia> A = AxisArray(rand(2,2), :x, :y)
2-dimensional AxisArray{Float64,2,...} with axes:
    :x, Base.OneTo(2)
    :y, Base.OneTo(2)
And data, a 2×2 Array{Float64,2}:
 0.695732   0.261082
 0.0772629  0.286141

julia> A[Axis{:y}(1), Axis{:y}(1)]
ERROR: UndefVarError: y not defined
 in to_index at /Users/ajkeller/.julia/v0.5/AxisArrays/src/indexing.jl:106 [inlined]
 in getindex(::AxisArrays.AxisArray{Float64,2,Array{Float64,2},Tuple{AxisArrays.Axis{:x,Base.OneTo{Int64}},AxisArrays.Axis{:y,Base.OneTo{Int64}}}}, ::AxisArrays.Axis{:y,Int64}, ::AxisArrays.Axis{:y,Int64}) at /Users/ajkeller/.julia/v0.5/AxisArrays/src/indexing.jl:76
```

In this PR, in addition to displaying the expected error message I've made it an `ArgumentError` rather than an `ErrorException`:

```
 julia> using AxisArrays
INFO: Recompiling stale cache file /Users/ajkeller/.julia/lib/v0.5/AxisArrays.ji for module AxisArrays.

julia> A = AxisArray(rand(2,2), :x, :y)
2-dimensional AxisArray{Float64,2,...} with axes:
    :x, Base.OneTo(2)
    :y, Base.OneTo(2)
And data, a 2×2 Array{Float64,2}:
 0.698423  0.522879
 0.957749  0.178753

julia> A[Axis{:y}(1), Axis{:y}(1)]
ERROR: ArgumentError: multiple indices provided on axis y
 in getindex(::AxisArrays.AxisArray{Float64,2,Array{Float64,2},Tuple{AxisArrays.Axis{:x,Base.OneTo{Int64}},AxisArrays.Axis{:y,Base.OneTo{Int64}}}}, ::AxisArrays.Axis{:y,Int64}, ::AxisArrays.Axis{:y,Int64}) at /Users/ajkeller/.julia/v0.5/AxisArrays/src/indexing.jl:76
```

I'll keep working my way towards a PR for `atvalue` as discussed earlier, I'm just trying to understand indexing better first.