### PR TITLE
Add steps/offsets convenience constructor:

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -94,6 +94,7 @@ immutable AxisArray{T,N,D,Ax} <: AbstractArray{T,N}
 AxisArray(A::AbstractArray, axes::Axis...)
 AxisArray(A::AbstractArray, names::Symbol...)
 AxisArray(A::AbstractArray, vectors::AbstractVector...)
+AxisArray(A::AbstractArray, (names...,), (steps...,), [(offsets...,)])
 ```
 
 ### Arguments
@@ -202,6 +203,10 @@ checknames() = ()
 AxisArray(A::AbstractArray) = AxisArray(A, ()) # Disambiguation
 AxisArray(A::AbstractArray, names::Symbol...)         = AxisArray(A, map((name,ind)->Axis{name}(ind), names, indices(A)))
 AxisArray(A::AbstractArray, vects::AbstractVector...) = AxisArray(A, ntuple(i->Axis{_defaultdimname(i)}(vects[i]), length(vects)))
+function AxisArray{T,N}(A::AbstractArray{T,N}, names::NTuple{N,Symbol}, steps::NTuple{N,Number}, offsets::NTuple{N,Number}=map(zero, steps))
+    axs = ntuple(i->Axis{names[i]}(range(offsets[i], steps[i], size(A,i))), N)
+    AxisArray(A, axs...)
+end
 
 # Traits
 immutable HasAxes{B} end

--- a/test/core.jl
+++ b/test/core.jl
@@ -117,6 +117,13 @@ A = AxisArray([0]', :x, :y)
 @test axisnames(@inferred(squeeze(A, Axis{:x,UnitRange{Int}}))) == (:y,)
 @test axisnames(@inferred(squeeze(A, Axis{:y}))) == (:x,)
 @test axisnames(@inferred(squeeze(squeeze(A, Axis{:x}), Axis{:y}))) == ()
+# Names, steps, and offsets
+B = AxisArray([1 4; 2 5; 3 6], (:x, :y), (0.2, 100))
+@test axisnames(B) == (:x, :y)
+@test axisvalues(B) == (0:0.2:0.4, 0:100:100)
+B = AxisArray([1 4; 2 5; 3 6], (:x, :y), (0.2, 100), (-3,14))
+@test axisnames(B) == (:x, :y)
+@test axisvalues(B) == (-3:0.2:-2.6, 14:100:114)
 
 @test AxisArrays.HasAxes(A)   == AxisArrays.HasAxes{true}()
 @test AxisArrays.HasAxes([1]) == AxisArrays.HasAxes{false}()


### PR DESCRIPTION
This adds a convenience constructor with the following syntax:
```jl
AxisArray(A::AbstractArray, (names...,), (steps...,), [(offsets...,)])
```
where `steps` is meant in the range-step sense, and `offsets` is like `start` for each coordinate. Requested in https://github.com/timholy/Images.jl/issues/542#issuecomment-270741009. I can add it to ImageAxes but I thought perhaps it would be worth gauging interest here first. CC @tknopp.

Is that one line in the docs enough, or does it need more explanation?