### PR TITLE
Fix 0.6 breakages and depwarns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ Collaboration is welcome! This is still a work-in-progress. See [the roadmap](ht
 
 ```julia
 julia> Pkg.clone("https://github.com/JuliaArrays/AxisArrays.jl")
-       using AxisArrays, SIUnits
-       import SIUnits.ShortUnits: s, ms, µs
+       using AxisArrays, Unitful
+       import Unitful: s, ms, µs
 
 julia> fs = 40000 # Generate a 40kHz noisy signal, with spike-like stuff added for testing
        y = randn(60*fs+1)*3
-       for spk = (sin(0.8:0.2:8.6) .* [0:0.01:.1; .15:.1:.95; 1:-.05:.05]   .* 50,
-                  sin(0.8:0.4:8.6) .* [0:0.02:.1; .15:.1:1; 1:-.2:.1] .* 50)
+       for spk = (sin.(0.8:0.2:8.6) .* [0:0.01:.1; .15:.1:.95; 1:-.05:.05]   .* 50,
+                  sin.(0.8:0.4:8.6) .* [0:0.02:.1; .15:.1:1; 1:-.2:.1] .* 50)
            i = rand(round(Int,.001fs):1fs)
            while i+length(spk)-1 < length(y)
                y[i:i+length(spk)-1] += spk
@@ -54,16 +54,15 @@ indices in *any* order, just so long as we annotate them with the axis name:
 
 ```jl
 julia> A[Axis{:time}(4)]
-2-dimensional AxisArray{Float64,2,...} with axes:
-    :time, 7.5e-5 s:2.5e-5 s:7.5e-5 s
-    :chan, [:c1,:c2]
-And data, a 1x2 SubArray{Float64,2,Array{Float64,2},Tuple{UnitRange{Int64},Colon},2}:
+2-dimensional AxisArray{Float64,1,...} with axes:
+    :chan, Symbol[:c1,:c2]
+And data, a 2-element Array{Float64,1}:
  -1.4144  -2.82879
 
 julia> A[Axis{:chan}(:c2), Axis{:time}(1:5)]
 1-dimensional AxisArray{Float64,1,...} with axes:
     :time, 0.0 s:2.5e-5 s:0.0001 s
-And data, a 5-element SubArray{Float64,1,Array{Float64,2},Tuple{UnitRange{Int64},Int64},2}:
+A[Axis{:chan}(:c2), Axis{:time}(1:5)]:
  -6.12181
   0.304668
  15.7366
@@ -80,7 +79,7 @@ still has the correct time information for those datapoints!
 julia> A[40µs .. 220µs, :c1]
 1-dimensional AxisArray{Float64,1,...} with axes:
     :time, 5.0e-5 s:2.5e-5 s:0.0002 s
-And data, a 7-element SubArray{Float64,1,Array{Float64,2},Tuple{UnitRange{Int64},Int64},2}:
+And data, a 7-element Array{Float64,1}:
   7.86831
  -1.4144
  -2.02881
@@ -90,7 +89,7 @@ And data, a 7-element SubArray{Float64,1,Array{Float64,2},Tuple{UnitRange{Int64}
  -1.97716
 
 julia> axes(ans, 1)
-AxisArrays.Axis{:time,SIUnits.SIRange{FloatRange{Float64},Float64,0,0,1,0,0,0,0,0,0}}(5.0e-5 s:2.5e-5 s:0.0002 s)
+AxisArrays.Axis{:time,StepRangeLen{Quantity{Float64, Dimensions:{𝐓}, Units:{s}},Base.TwicePrecision{Quantity{Float64, Dimensions:{𝐓}, Units:{s}}},Base.TwicePrecision{Quantity{Float64, Dimensions:{𝐓}, Units:{s}}}}}(5.0e-5 s:2.5e-5 s:0.0002 s)
 ```
 
 Sometimes, though, what we're really interested in is a window of time about a
@@ -125,7 +124,7 @@ julia> idxs = find(diff(A[:,:c1] .< -15) .> 0)
 julia> spks = A[atindex(-200µs .. 800µs, idxs), :c1]
 2-dimensional AxisArray{Float64,2,...} with axes:
     :time_sub, -0.000175 s:2.5e-5 s:0.000775 s
-    :time_rep, SIUnits.SIQuantity{Float64,0,0,1,0,0,0,0,0,0}[0.178725 s,0.806825 s,0.88305 s,1.47485 s,1.50465 s,1.53805 s,1.541025 s,2.16365 s,2.368425 s,2.739 s  …  57.797925 s,57.924075 s,58.06075 s,58.215125 s,58.6403 s,58.96215 s,58.990225 s,59.001325 s,59.48395 s,59.611525 s]
+    :time_rep, Quantity{Float64, Dimensions:{𝐓}, Units:{s}}[0.178725 s,0.806825 s,0.88305 s,1.47485 s,1.50465 s,1.53805 s,1.541025 s,2.16365 s,2.368425 s,2.739 s  …  57.797925 s,57.924075 s,58.06075 s,58.215125 s,58.6403 s,58.96215 s,58.990225 s,59.001325 s,59.48395 s,59.611525 s]
 And data, a 39x242 Array{Float64,2}:
  -1.53038     4.72882     5.8706    …  -0.231564      0.624714   3.44076
  -2.24961     2.12414     5.69936       7.00179       2.30993    5.20432

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.5
 IntervalSets
 Iterators
 RangeArrays
+Compat 0.19

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -4,6 +4,7 @@ module AxisArrays
 
 using Base: tail
 using RangeArrays, Iterators, IntervalSets
+using Compat
 
 export AxisArray, Axis, axisnames, axisvalues, axisdim, axes, atindex
 

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -13,7 +13,7 @@ sizes{T<:AxisArray}(As::T...) = tuple(zip(map(size, As)...)...)
 matchingdims{N,T<:AxisArray}(As::NTuple{N,T}) = all(equalvalued, sizes(As...))
 matchingdimsexcept{N,T<:AxisArray}(As::NTuple{N,T}, n::Int) = all(equalvalued, sizes(As[[1:n-1; n+1:end]]...))
 
-function Base.cat{T<:AxisArray}(n::Integer, As::T...)
+function Base.cat{T}(n::Integer, As::AxisArray{T}...)
     if n <= ndims(As[1])
         matchingdimsexcept(As, n) || error("All non-concatenated axes must be identically-valued")
         newaxis = Axis{axisnames(As[1])[n]}(vcat(map(A -> A.axes[n].val, As)...))

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -17,7 +17,7 @@
 # downside is that Intervals are not as useful as they could be; they really
 # could be considered as <: Number themselves. We do this in general for any
 # supported Scalar:
-typealias Scalar Union{Number, Dates.AbstractTime}
+const Scalar = Union{Number, Dates.AbstractTime}
 Base.promote_rule{T<:Scalar}(::Type{ClosedInterval{T}}, ::Type{T}) = ClosedInterval{T}
 Base.promote_rule{T,S<:Scalar}(::Type{ClosedInterval{T}}, ::Type{S}) = ClosedInterval{promote_type(T,S)}
 Base.promote_rule{T,S}(::Type{ClosedInterval{T}}, ::Type{ClosedInterval{S}}) = ClosedInterval{promote_type(T,S)}
@@ -62,7 +62,7 @@ immutable RepeatedInterval{T,S,A} <: AbstractVector{T}
 end
 RepeatedInterval{S,A<:AbstractVector}(window::ClosedInterval{S}, offsets::A) = RepeatedInterval{promote_type(ClosedInterval{S}, eltype(A)), S, A}(window, offsets)
 Base.size(r::RepeatedInterval) = size(r.offsets)
-Base.linearindexing{R<:RepeatedInterval}(::Type{R}) = Base.LinearFast()
+@compat Base.IndexStyle(::Type{<:RepeatedInterval}) = IndexLinear()
 Base.getindex(r::RepeatedInterval, i::Int) = r.window + r.offsets[i]
 +(window::ClosedInterval, offsets::AbstractVector) = RepeatedInterval(window, offsets)
 +(offsets::AbstractVector, window::ClosedInterval) = RepeatedInterval(window, offsets)
@@ -84,5 +84,5 @@ immutable RepeatedIntervalAtIndexes{T,A<:AbstractVector{Int}} <: AbstractVector{
 end
 atindex(window::ClosedInterval, indexes::AbstractVector) = RepeatedIntervalAtIndexes(window, indexes)
 Base.size(r::RepeatedIntervalAtIndexes) = size(r.indexes)
-Base.linearindexing{R<:RepeatedIntervalAtIndexes}(::Type{R}) = Base.LinearFast()
+@compat Base.IndexStyle(::Type{<:RepeatedIntervalAtIndexes}) = IndexLinear()
 Base.getindex(r::RepeatedIntervalAtIndexes, i::Int) = IntervalAtIndex(r.window, r.indexes[i])

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,2 @@
 OffsetArrays
-SIUnits
+Unitful

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -37,8 +37,13 @@ D[1,1,1,1,1] = 10
 
 # Linear indexing across multiple dimensions drops tracking of those dims
 @test A[:].axes[1].val == 1:length(A)
-@test A[1:2,:].axes[1].val == A.axes[1].val[1:2]
-@test A[1:2,:].axes[2].val == 1:Base.trailingsize(A,2)
+B = A[1:2,:]
+@test B.axes[1].val == A.axes[1].val[1:2]
+@test B.axes[2].val == 1:Base.trailingsize(A,2)
+B2 = reshape(A, Val{2})
+B = B2[1:2,:]
+@test B.axes[1].val == A.axes[1].val[1:2]
+@test B.axes[2].val == 1:Base.trailingsize(A,2)
 
 B = AxisArray(reshape(1:15, 5,3), .1:.1:0.5, [:a, :b, :c])
 

--- a/test/readme.jl
+++ b/test/readme.jl
@@ -1,12 +1,12 @@
 # Intended to ensure the README stays working (this is a copy)
 
-using AxisArrays, SIUnits
-import SIUnits.ShortUnits: s, ms, µs
+using AxisArrays, Unitful
+import Unitful: s, ms, µs
 
 fs = 40000
 y = randn(60*fs+1)*3
-for spk = (sin(0.8:0.2:8.6) .* [0:0.01:.1; .15:.1:.95; 1:-.05:.05]   .* 50,
-           sin(0.8:0.4:8.6) .* [0:0.02:.1; .15:.1:1; 1:-.2:.1] .* 50)
+for spk = (sin.(0.8:0.2:8.6) .* [0:0.01:.1; .15:.1:.95; 1:-.05:.05]   .* 50,
+           sin.(0.8:0.4:8.6) .* [0:0.02:.1; .15:.1:1; 1:-.2:.1] .* 50)
     i = rand(round(Int,.001fs):1fs)
     while i+length(spk)-1 < length(y)
         y[i:i+length(spk)-1] += spk

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,9 @@
 using AxisArrays
 using Base.Test
 
-@test isempty(detect_ambiguities(AxisArrays, Base, Core))
+if VERSION < v"0.6.0-dev"
+    @test isempty(detect_ambiguities(AxisArrays, Base, Core))
+end
 
 include("core.jl")
 include("intervals.jl")


### PR DESCRIPTION
I think this gets most of the recent depwarns & breakages. Will require a new Compat tag (https://github.com/JuliaLang/Compat.jl/pull/329). Also doesn't fix
```julia
ArgumentError: colons must be converted by to_indices(...)
  Stacktrace:
   [1] macro expansion at /home/tim/.julia/v0.6/AxisArrays/src/indexing.jl:47 [inlined]
   [2] reaxis at /home/tim/.julia/v0.6/AxisArrays/src/indexing.jl:18 [inlined]
   [3] getindex at /home/tim/.julia/v0.6/AxisArrays/src/indexing.jl:52 [inlined]
   [4] getindex(::AxisArrays.AxisArray{Float64,2,Array{Float64,2},Tuple{AxisArrays.Axis{:Timestamp,StepRange{DateTime,Base.Dates.Hour}},AxisArrays.Axis{:Cols,Array{Symbol,1}}}}, ::Colon, ::Symbol) at /home/tim/.julia/v0.6/AxisArrays/src/indexing.jl:76
   [5] include_from_node1(::String) at ./loading.jl:539
   [6] include(::String) at ./sysimg.jl:14
   [7] include_from_node1(::String) at ./loading.jl:539
   [8] include(::String) at ./sysimg.jl:14
   [9] eval(::Module, ::Any) at ./boot.jl:235
   [10] eval_user_input(::Any, ::Base.REPL.REPLBackend) at ./REPL.jl:66
   [11] macro expansion at ./REPL.jl:97 [inlined]
   [12] (::Base.REPL.##1#2{Base.REPL.REPLBackend})() at ./event.jl:73
ERROR: LoadError: LoadError: There was an error during testing
while loading /home/tim/.julia/v0.6/AxisArrays/test/core.jl, in expression starting on line 177
while loading /home/tim/.julia/v0.6/AxisArrays/test/runtests.jl, in expression starting on line 8
```

Wouldn't mind a little collaboration in fixing that particular problem :smile:. If anyone is interested, feel free to grab this and run with it.