### PR TITLE
Let axistrait and checkaxis take Axis arguments

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -426,9 +426,11 @@ immutable Categorical <: AxisTrait end
 immutable Unsupported <: AxisTrait end
 
 axistrait(::Any) = Unsupported
+axistrait(ax::Axis) = axistrait(ax.val)
 axistrait{T<:Union{Number, Dates.AbstractTime}}(::AbstractVector{T}) = Dimensional
 axistrait{T<:Union{Symbol, AbstractString}}(::AbstractVector{T}) = Categorical
 
+checkaxis(ax::Axis) = checkaxis(ax.val)
 checkaxis(ax) = checkaxis(axistrait(ax), ax)
 checkaxis(::Type{Unsupported}, ax) = nothing # TODO: warn or error?
 # Dimensional axes must be monotonically increasing

--- a/test/core.jl
+++ b/test/core.jl
@@ -179,6 +179,14 @@ A = AxisArray(vals, Axis{:Timestamp}(dt-Dates.Hour(2):Dates.Hour(1):dt+Dates.Hou
 @test A[:, :A].data == vals[:, 1]
 @test A[dt, :].data == vals[3, :]
 
+@test AxisArrays.axistrait(A.axes[1]) == AxisArrays.Dimensional
+@test AxisArrays.axistrait(A.axes[1].val) == AxisArrays.Dimensional
+@test AxisArrays.axistrait(A.axes[2]) == AxisArrays.Categorical
+@test AxisArrays.axistrait(A.axes[2].val) == AxisArrays.Categorical
+
+@test_throws ArgumentError AxisArrays.checkaxis(Axis{:x}(10:-1:1))
+@test_throws ArgumentError AxisArrays.checkaxis(10:-1:1)
+
 # Simply run the display method to ensure no stupid errors
 show(IOBuffer(),MIME("text/plain"),A)
 


### PR DESCRIPTION
Adds methods to `axistrait` and `checkaxis` that accept `Axis` arguments, for consistency with other functions like `axisname` and `axisvalues`.