### PR TITLE
merge and join speedups

### DIFF
--- a/src/combine.jl
+++ b/src/combine.jl
@@ -67,13 +67,33 @@ function indexmapping(old::AbstractVector, new::AbstractVector)
     before = Int[]
     after = Int[]
 
-    # TODO: Presort for O(n)
-    for i in eachindex(old)
-        j = findfirst(new, old[i])
-        if j > 0
-            push!(before, i)
-            push!(after, j)
+    oldperm = sortperm(old)
+    newperm = sortperm(new)
+
+    oldsorted = old[oldperm]
+    newsorted = new[newperm]
+
+    oldlength = length(old)
+    newlength = length(new)
+
+    oi = ni = 1
+
+    while oi <= oldlength && ni <= newlength
+
+        oldval = oldsorted[oi]
+        newval = newsorted[ni]
+
+        if oldval == newval
+            push!(before, oldperm[oi])
+            push!(after, newperm[ni])
+            oi += 1
+            ni += 1
+        elseif oldval < newval
+            oi += 1
+        else
+            ni += 1
         end
+
     end
 
     return before, after

--- a/src/combine.jl
+++ b/src/combine.jl
@@ -121,7 +121,9 @@ Combines AxisArrays with matching axis names into a single AxisArray. Unlike `me
 
 If an array value in the output array is not defined in any of the input arrays (i.e. in the case of a left, right, or outer join), it takes the value of the optional `fillvalue` keyword argument (default zero).
 """
-function Base.join{T,N,D,Ax}(As::AxisArray{T,N,D,Ax}...; fillvalue::T=zero(T), newaxis::Axis=Axis{_defaultdimname(N+1)}(1:length(As)), method::Symbol=:outer)
+function Base.join{T,N,D,Ax}(As::AxisArray{T,N,D,Ax}...; fillvalue::T=zero(T),
+                             newaxis::Axis=_nextaxistype(As[1].data, As[1].axes)(1:length(As)),
+                             method::Symbol=:outer)
 
     prejoin_resultaxes = map(as -> axismerge(method, as...), map(tuple, axes.(As)...))
 


### PR DESCRIPTION
This is a rewrite of `merge` and `join` to improve performance by an order of magnitude.

```julia
using AxisArrays
data = randn(400, 100, 50);
A1 = AxisArray(data, Axis{:time}(1:400), Axis{:lon}(1:100), Axis{:lat}(1:50))
A2 = AxisArray(data, Axis{:time}(401:800), Axis{:lon}(1:100), Axis{:lat}(1:50))
```

Master:

```julia
julia> @time merge(A1, A2);
 11.517995 seconds (113.78 M allocations: 4.252 GB, 4.12% gc time)

julia> @time join(A1, A2);
 15.268915 seconds (131.22 M allocations: 5.025 GB, 4.67% gc time)
```

This PR:

```julia
julia> @time merge(A1, A2);
  0.806035 seconds (16.01 M allocations: 1.788 GB, 23.98% gc time)

julia> @time join(A1, A2);
  0.838161 seconds (16.01 M allocations: 1.848 GB, 23.06% gc time)
```