### PR TITLE
Use step(r) instead of r.step...

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -59,7 +59,7 @@ else
     @inline inbounds_getindex(r::StepRangeLen, i::Integer) = Base.unsafe_getindex(r, i)
     @inline function inbounds_getindex(r::StepRangeLen, s::OrdinalRange)
         vfirst = Base.unsafe_getindex(r, first(s))
-        StepRangeLen(vfirst, r.step*step(s), length(s))
+        StepRangeLen(vfirst, step(r)*step(s), length(s))
     end
     """)
 end

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -114,7 +114,7 @@ AxisArrays.axistrait(::AbstractVector{IntLike}) = AxisArrays.Dimensional
 end
 
 for (r, Irel) in ((0.1:0.1:10.0, -0.5..0.5),  # FloatRange
-                  (linspace(0.1, 10.0, 100), -0.5..0.5),  # LinSpace
+                  (linspace(0.1, 10.0, 100), -0.51..0.51),  # LinSpace
                   (IL.IntLike(1):IL.IntLike(1):IL.IntLike(100),
                    IL.IntLike(-5)..IL.IntLike(5))) # StepRange
     Iabs = r[20]..r[30]

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -114,6 +114,7 @@ AxisArrays.axistrait(::AbstractVector{IntLike}) = AxisArrays.Dimensional
 end
 
 for (r, Irel) in ((0.1:0.1:10.0, -0.5..0.5),  # FloatRange
+                  (linspace(0.1, 10.0, 100), -0.5..0.5),  # LinSpace
                   (IL.IntLike(1):IL.IntLike(1):IL.IntLike(100),
                    IL.IntLike(-5)..IL.IntLike(5))) # StepRange
     Iabs = r[20]..r[30]
@@ -127,6 +128,9 @@ for (r, Irel) in ((0.1:0.1:10.0, -0.5..0.5),  # FloatRange
     @test A[r[[25, 35]] + Irel,  :c1] == [20:30 30:40]
     @test_throws BoundsError A[atindex(Irel, 5), :c1]
     @test_throws BoundsError A[atindex(Irel, [5, 15, 25]), :]
+
+    B = A[r[[25, 35]] + Irel,  :c1]
+    @test B[:,:] == B[Irel, :] == [20:30 30:40]
 end
 
 # Indexing with CartesianIndex


### PR DESCRIPTION
when constructing StepRangeLen objects. This came up when using the new LinSpace objects -- their r.step is a DoublePrecision, which causes all sorts of downstream promotion/interaction problems. `step(r)` returns the ordinary precision number I expected. The fact that we this currently has `r.step` and `step(s)` immediately juxtaposed makes me think that using the field directly was intentional... but nothing breaks.