### PR TITLE
Remove Iterators from REQUIRES

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,4 @@
 julia 0.5
 IntervalSets
-Iterators
 RangeArrays
 Compat 0.19

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -2,7 +2,6 @@ __precompile__()
 
 module AxisArrays
 
-using Base.Iterators
 using Base: tail
 using RangeArrays, IntervalSets
 using Compat

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -2,8 +2,9 @@ __precompile__()
 
 module AxisArrays
 
+using Base.Iterators
 using Base: tail
-using RangeArrays, Iterators, IntervalSets
+using RangeArrays, IntervalSets
 using Compat
 
 export AxisArray, Axis, axisnames, axisvalues, axisdim, axes, atindex


### PR DESCRIPTION
No longer needed, and it fixes https://github.com/JuliaImages/ImageAxes.jl/issues/18.