### PR TITLE
Add concrete version bounds to ambiguity test gate

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,8 @@ using AxisArrays
 using Base.Test
 
 @testset "AxisArrays" begin
-    if VERSION < v"0.6.0-dev"
+    # during this time there was an ambiguity in base with checkbounds_linear_indices
+    if VERSION < v"0.6.0-dev.2374" || VERSION >= v"0.6.0-dev.2884"
         @test isempty(detect_ambiguities(AxisArrays, Base, Core))
     end
 


### PR DESCRIPTION
We were avoiding this test on 0.6 as there were ambiguities in Base but there is no need for that anymore. 