### PR TITLE
Allow failures on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ julia:
   - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+  - julia: nightly
 # uncomment the following lines to override the default test script
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi


### PR DESCRIPTION
Nightly is going to be a moving target for a while so we might as well have a green badge for official versions of Julia.