### PR TITLE
Indexing by an array of values

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ And data, a 1-element Array{Float64,1}:
  6.14454
 ```
 
+You can even index by multiple values by broadcasting `atvalue` over an array:
+
+```julia
+julia> A[atvalue.([2.5e-5s, 75.0µs])]
+2-dimensional AxisArray{Float64,2,...} with axes:
+    :time, Quantity{Float64, Dimensions:{𝐓}, Units:{s}}[2.5e-5 s, 7.5e-5 s]
+    :chan, Symbol[:c1, :c2]
+And data, a 2×2 Array{Float64,2}:
+ 6.14454  12.2891
+ 1.37825   2.75649
+```
+
 Sometimes, though, what we're really interested in is a window of time about a
 specific index. One of the operations above (looking for values in the window from 40µs
 to 220µs) might be more clearly expressed as a symmetrical window about a

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -137,6 +137,18 @@ And data, a 1-element Array{Float64,1}:
  6.14454
 ```
 
+You can even index by multiple values by broadcasting `atvalue` over an array:
+
+```jldoctest
+julia> A[atvalue.([2.5e-5s, 75.0µs])]
+2-dimensional AxisArray{Float64,2,...} with axes:
+    :time, Quantity{Float64, Dimensions:{𝐓}, Units:{s}}[2.5e-5 s, 7.5e-5 s]
+    :chan, Symbol[:c1, :c2]
+And data, a 2×2 Array{Float64,2}:
+ 6.14454  12.2891
+ 1.37825   2.75649
+```
+
 Sometimes, though, what we're really interested in is a window of time about a
 specific index. One of the operations above (looking for values in the window from 40µs
 to 220µs) might be more clearly expressed as a symmetrical window about a

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -8,6 +8,7 @@ struct Value{T}
 end
 Value(x, tol=Base.rtoldefault(typeof(x))*abs(x)) = Value(promote(x,tol)...)
 atvalue(x; rtol=Base.rtoldefault(typeof(x)), atol=zero(x)) = Value(x, atol+rtol*abs(x))
+const Values = AbstractArray{<:Value}
 
 # For throwing a BoundsError with a Value index, we need to define the following
 # (note that we could inherit them for free, were Value <: Number)
@@ -280,6 +281,9 @@ end
             n += 1
         elseif I[i] <: AbstractArray{Bool}
             push!(ex.args, :(find(I[$i])))
+            n += 1
+        elseif I[i] <: Values
+            push!(ex.args, :(axisindexes.(A.axes[$i], I[$i])))
             n += 1
         elseif I[i] <: CartesianIndex
             for j = 1:length(I[i])

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -196,6 +196,11 @@ A = AxisArray([1 2; 3 4], Axis{:x}([1.0,4.0]), Axis{:y}([2.0,6.1]))
 @test @inferred(A[Axis{:x}(atvalue(2.0, atol=5))]) == [1,2]
 @test_throws BoundsError A[Axis{:x}(atvalue(4.00000001, rtol=0))]
 
+# Indexing by array of values
+A = AxisArray([1 2 3 4; 5 6 7 8; 9 10 11 12], -1:1, [5.1, 5.4, 5.7, 5.8])
+@test @inferred(A[atvalue(-1), atvalue.([5.1, 5.7])]) == [1, 3]
+@test_throws BoundsError A[atvalue.([1,2])]
+
 # Indexing by value into an OffsetArray
 A = AxisArray(OffsetArrays.OffsetArray([1 2; 3 4], 0:1, 1:2),
     Axis{:x}([1.0,4.0]), Axis{:y}([2.0,6.1]))


### PR DESCRIPTION
Now that #52 has been merged, this PR attempts to address #84, except for the "by default" part. Simply broadcast `atvalue`:

```
julia> A = AxisArray(rand(7), Axis{:x}(-3:3))
1-dimensional AxisArray{Float64,1,...} with axes:
    :x, -3:3
And data, a 7-element Array{Float64,1}:
 0.44085 
 0.77351 
 0.192314
 0.904178
 0.912603
 0.485005
 0.730789

julia> A[atvalue.([-2,1])]
1-dimensional AxisArray{Float64,1,...} with axes:
    :x, [-2, 1]
And data, a 2-element Array{Float64,1}:
 0.77351 
 0.912603
```

With many dimensions, I concede that typing `atvalue` repeatedly might become tiresome. Perhaps in some follow-up PR I might implement a macro (`@value`?) for splicing `atvalue` repeatedly into an expression if a user wants to index all dimensions by value. I would guess that should be possible though I haven't tried or thought too deeply about it.