### PR TITLE
Upgrade syntax to 1.0-valid constructs (`where` and `struct`)

### DIFF
--- a/src/categoricalvector.jl
+++ b/src/categoricalvector.jl
@@ -62,9 +62,9 @@ checkaxis(::CategoricalVector) = nothing
 ## Add some special indexing for CategoricalVector{Tuple}'s to achieve something like
 ## Panda's hierarchical indexing
 
-axisindexes{T<:Tuple,S,A}(ax::Axis{S,CategoricalVector{T,A}}, idx) = axisindexes(ax, (idx,))
+axisindexes(ax::Axis{S,CategoricalVector{T,A}}, idx) where {T<:Tuple,S,A} = axisindexes(ax, (idx,))
 
-function axisindexes{T<:Tuple,S,A}(ax::Axis{S,CategoricalVector{T,A}}, idx::Tuple)
+function axisindexes(ax::Axis{S,CategoricalVector{T,A}}, idx::Tuple) where {T<:Tuple,S,A}
     collect(filter(ax_idx->_tuple_matches(ax.val[ax_idx], idx), indices(ax.val)...))
 end
 
@@ -78,5 +78,5 @@ function _tuple_matches(element::Tuple, idx::Tuple)
     return true
 end
 
-axisindexes{T<:Tuple,S,A}(ax::Axis{S,CategoricalVector{T,A}}, idx::AbstractArray) =
+axisindexes(ax::Axis{S,CategoricalVector{T,A}}, idx::AbstractArray) where {T<:Tuple,S,A} =
     vcat([axisindexes(ax, i) for i in idx]...)

--- a/src/categoricalvector.jl
+++ b/src/categoricalvector.jl
@@ -39,7 +39,7 @@ A[(:a,:x), :]
 A[(:a,:x,:x), :]
 ```
 """
-immutable CategoricalVector{T, A<:AbstractVector{T}} <: AbstractVector{T}
+struct CategoricalVector{T, A<:AbstractVector{T}} <: AbstractVector{T}
     data::A
 end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,12 +1,6 @@
 # Core types and definitions
 
-if VERSION < v"0.5.0-dev"
-    macro pure(ex)
-        esc(ex)
-    end
-else
-    using Base: @pure
-end
+using Base: @pure
 
 const Symbols = Tuple{Symbol,Vararg{Symbol}}
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -11,7 +11,7 @@ parametric type.
 ### Type parameters
 
 ```julia
-immutable Axis{name,T}
+struct Axis{name,T}
 ```
 * `name` : the name of the axis, a Symbol
 * `T` : the type of the axis
@@ -42,7 +42,7 @@ A[Axis{2}(2:5)] # grabs the second through 5th columns
 ```
 
 """
-immutable Axis{name,T}
+struct Axis{name,T}
     val::T
 end
 # Constructed exclusively through Axis{:symbol}(...) or Axis{1}(...)
@@ -75,7 +75,7 @@ dimension. Other advanced indexing along axis values are also provided.
 The AxisArray contains several type parameters:
 
 ```julia
-immutable AxisArray{T,N,D,Ax} <: AbstractArray{T,N}
+struct AxisArray{T,N,D,Ax} <: AbstractArray{T,N}
 ```
 * `T` : the elemental type of the AbstractArray
 * `N` : the number of dimensions
@@ -143,7 +143,7 @@ A[ClosedInterval(0.,.3), [:a, :c]]   # select an interval and two columns
 ```
 
 """
-immutable AxisArray{T,N,D,Ax} <: AbstractArray{T,N}
+struct AxisArray{T,N,D,Ax} <: AbstractArray{T,N}
     data::D  # D <:AbstractArray, enforced in constructor to avoid dispatch bugs (https://github.com/JuliaLang/julia/issues/6383)
     axes::Ax # Ax<:NTuple{N, Axis}, but with specialized Axis{...} types
     (::Type{AxisArray{T,N,D,Ax}})(data::AbstractArray{T,N}, axs::Tuple{Vararg{Axis,N}}) where {T,N,D,Ax} = new{T,N,D,Ax}(data, axs)
@@ -211,7 +211,7 @@ function AxisArray(A::AbstractArray{T,N}, names::NTuple{N,Symbol}, steps::NTuple
 end
 
 # Traits
-immutable HasAxes{B} end
+struct HasAxes{B} end
 HasAxes(::Type{<:AxisArray}) = HasAxes{true}()
 HasAxes(::Type{<:AbstractArray}) = HasAxes{false}()
 HasAxes(::A) where A<:AbstractArray = HasAxes(A)
@@ -502,9 +502,9 @@ axisparams(::Type{AxisArray{T,N,D,Ax}}) where {T,N,D,Ax} = (Ax.parameters...)
 
 ### Axis traits ###
 abstract type AxisTrait end
-immutable Dimensional <: AxisTrait end
-immutable Categorical <: AxisTrait end
-immutable Unsupported <: AxisTrait end
+struct Dimensional <: AxisTrait end
+struct Categorical <: AxisTrait end
+struct Unsupported <: AxisTrait end
 
 """
     axistrait(ax::Axis) -> Type{<:AxisTrait}

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -2,7 +2,7 @@ const Idx = Union{Real,Colon,AbstractArray{Int}}
 
 using Base: ViewIndex, @propagate_inbounds, tail
 
-immutable Value{T}
+struct Value{T}
     val::T
     tol::T
 end

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -55,7 +55,7 @@ end
 
 # And, finally, we have an Array-of-Structs to Struct-of-Arrays transform for
 # the common case where the interval is constant over many offsets:
-immutable RepeatedInterval{T,S,A} <: AbstractVector{T}
+struct RepeatedInterval{T,S,A} <: AbstractVector{T}
     window::ClosedInterval{S}
     offsets::A # A <: AbstractVector
 end
@@ -71,14 +71,14 @@ Base.getindex(r::RepeatedInterval, i::Int) = r.window + r.offsets[i]
 
 # As a special extension to intervals, we allow specifying Intervals about a
 # particular index, which is resolved by an axis upon indexing.
-immutable IntervalAtIndex{T}
+struct IntervalAtIndex{T}
     window::ClosedInterval{T}
     index::Int
 end
 atindex(window::ClosedInterval, index::Integer) = IntervalAtIndex(window, index)
 
 # And similarly, an AoS -> SoA transform:
-immutable RepeatedIntervalAtIndexes{T,A<:AbstractVector{Int}} <: AbstractVector{IntervalAtIndex{T}}
+struct RepeatedIntervalAtIndexes{T,A<:AbstractVector{Int}} <: AbstractVector{IntervalAtIndex{T}}
     window::ClosedInterval{T}
     indexes::A # A <: AbstractVector{Int}
 end

--- a/src/intervals.jl
+++ b/src/intervals.jl
@@ -18,8 +18,8 @@
 # could be considered as <: Number themselves. We do this in general for any
 # supported Scalar:
 const Scalar = Union{Number, Dates.AbstractTime}
-Base.promote_rule{T<:Scalar}(::Type{ClosedInterval{T}}, ::Type{T}) = ClosedInterval{T}
-Base.promote_rule{T,S<:Scalar}(::Type{ClosedInterval{T}}, ::Type{S}) = ClosedInterval{promote_type(T,S)}
+Base.promote_rule(::Type{ClosedInterval{T}}, ::Type{T}) where {T<:Scalar} = ClosedInterval{T}
+Base.promote_rule(::Type{ClosedInterval{T}}, ::Type{S}) where {T,S<:Scalar} = ClosedInterval{promote_type(T,S)}
 
 import Base: isless, <=, >=, ==, +, -, *, /, ^, //
 # TODO: Is this a total ordering? (antisymmetric, transitive, total)?
@@ -59,7 +59,8 @@ immutable RepeatedInterval{T,S,A} <: AbstractVector{T}
     window::ClosedInterval{S}
     offsets::A # A <: AbstractVector
 end
-RepeatedInterval{S,A<:AbstractVector}(window::ClosedInterval{S}, offsets::A) = RepeatedInterval{promote_type(ClosedInterval{S}, eltype(A)), S, A}(window, offsets)
+RepeatedInterval(window::ClosedInterval{S}, offsets::A) where {S,A<:AbstractVector} =
+    RepeatedInterval{promote_type(ClosedInterval{S}, eltype(A)), S, A}(window, offsets)
 Base.size(r::RepeatedInterval) = size(r.offsets)
 Base.IndexStyle(::Type{<:RepeatedInterval}) = IndexLinear()
 Base.getindex(r::RepeatedInterval, i::Int) = r.window + r.offsets[i]

--- a/src/search.jl
+++ b/src/search.jl
@@ -46,11 +46,11 @@ function searchsorted(a::Range, I::ClosedInterval)
     searchsortedfirst(a, I.left):searchsortedlast(a, I.right)
 end
 
-# When running with "--check-bounds=yes`(like on Travis), the bounds-check isn't elided
-@inline function getindex{T}(v::Range{T}, i::Integer)
+# When running with `--check-bounds=yes` (like on Travis), the bounds-check isn't elided
+@inline function getindex(v::Range{T}, i::Integer) where T
     convert(T, first(v) + (i-1)*step(v))
 end
-@inline function getindex{T<:Integer}(r::Range, s::Range{T})
+@inline function getindex(r::Range, s::Range{<:Integer})
     f = first(r)
     st = oftype(f, f + (first(s)-1)*step(r))
     range(st, step(r)*step(s), length(s))
@@ -78,19 +78,19 @@ function searchsortedfirst(a::Range, x)
     n = round(Integer,(x-first(a))/step(a))+1
     isless(getindex(a, n), x) ? n+1 : n
 end
-function searchsortedlast{T<:Integer}(a::Range{T}, x)
+function searchsortedlast(a::Range{<:Integer}, x)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     fld(floor(Integer,x)-first(a),step(a))+1
 end
-function searchsortedfirst{T<:Integer}(a::Range{T}, x)
+function searchsortedfirst(a::Range{<:Integer}, x)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     -fld(floor(Integer,-x)+first(a),step(a))+1
 end
-function searchsortedfirst{T<:Integer}(a::Range{T}, x::Unsigned)
+function searchsortedfirst(a::Range{<:Integer}, x::Unsigned)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     -fld(first(a)-signed(x),step(a))+1
 end
-function searchsortedlast{T<:Integer}(a::Range{T}, x::Unsigned)
+function searchsortedlast(a::Range{<:Integer}, x::Unsigned)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     fld(signed(x)-first(a),step(a))+1
 end

--- a/src/sortedvector.jl
+++ b/src/sortedvector.jl
@@ -49,7 +49,7 @@ A[ClosedInterval((:a,:x),(:b,:x)), :]
 ```
 
 """
-immutable SortedVector{T} <: AbstractVector{T}
+struct SortedVector{T} <: AbstractVector{T}
     data::AbstractVector{T}
 end
 

--- a/src/sortedvector.jl
+++ b/src/sortedvector.jl
@@ -65,17 +65,17 @@ Base.size(v::SortedVector) = size(v.data)
 Base.size(v::SortedVector, i) = size(v.data, i)
 Base.indices(v::SortedVector) = indices(v.data)
 
-axistrait{T}(::Type{SortedVector{T}}) = Dimensional
+axistrait(::Type{<:SortedVector}) = Dimensional
 checkaxis(::SortedVector) = nothing
 
 
 ## Add some special indexing for SortedVector{Tuple}'s to achieve something like
 ## Panda's hierarchical indexing
 
-axisindexes{T<:Tuple,S}(ax::Axis{S,SortedVector{T}}, idx) =
+axisindexes(ax::Axis{S,SortedVector{T}}, idx) where {T<:Tuple,S} =
     searchsorted(ax.val, idx, 1, length(ax.val), Base.ord(_isless,identity,false,Base.Forward))
 
-axisindexes{T<:Tuple,S}(ax::Axis{S,SortedVector{T}}, idx::AbstractArray) =
+axisindexes(ax::Axis{S,SortedVector{T}}, idx::AbstractArray) where {T<:Tuple,S} =
     vcat([axisindexes(ax, i) for i in idx]...)
 
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -107,7 +107,7 @@ v = AxisArray(collect(.1:.1:10.0), .1:.1:10.0)
 # create a number type from which we build a StepRange but which is
 # not an Int.
 module IL  # put in a module so this file can be re-run
-immutable IntLike <: Number
+struct IntLike <: Number
     val::Int
 end
 Base.one(x::IntLike) = IntLike(0)


### PR DESCRIPTION
Upgrades all method parameters to `where` syntax and all types from `immutable` to `struct`. It turns out we never make mutable types, which is nice. Also removed the last version check.