### PR TITLE
Constructor over an AxisArray

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -216,6 +216,12 @@ function AxisArray{T,N}(A::AbstractArray{T,N}, names::NTuple{N,Symbol}, steps::N
     AxisArray(A, axs...)
 end
 
+AxisArray(A::AxisArray) = A
+AxisArray(A::AxisArray, ax::Vararg{Axis, N}) where N =
+    AxisArray(A.data, ax..., last(Base.IteratorsMD.split(axes(A), Val{N}))...)
+AxisArray(A::AxisArray, ax::NTuple{N, Axis}) where N =
+    AxisArray(A.data, ax..., last(Base.IteratorsMD.split(axes(A), Val{N}))...)
+
 # Traits
 immutable HasAxes{B} end
 HasAxes{A<:AxisArray}(::Type{A}) = HasAxes{true}()

--- a/test/core.jl
+++ b/test/core.jl
@@ -145,6 +145,18 @@ A = @inferred(AxisArray(reshape(1:24, 2,3,4),
               Axis{:y}(1//10:1//10:3//10),
               Axis{:z}(["a", "b", "c", "d"])))
 
+# recursive constructor
+@test A === @inferred AxisArray(A)
+@test axisnames(AxisArray(A, Axis{:yoyo}(1:length(A[Axis{:x}])))) == (:yoyo, :y, :z)
+@test AxisArray(A, Axis{:yoyo}(1:length(A[Axis{:x}]))).data === A.data
+@test AxisArray(A, (Axis{:yoyo}(1:length(A[Axis{:x}])),)).data === A.data
+@test axisnames(AxisArray(A, :something, :in, :the)) == (:something, :in, :the)
+@test AxisArray(A, :way, :you, :move).data === A.data
+@test axisnames(AxisArray(A, (:c, :a, :b), (2, 3, 4))) == (:c, :a, :b)
+@test AxisArray(A, (:c, :a, :b), (2, 3, 4)).data === A.data
+@inferred AxisArray(A, Axis{:yoyo}(1:length(A[Axis{:x}])))
+@inferred AxisArray(A, (Axis{:yoyo}(1:length(A[Axis{:x}])),))
+
 # Test axisdim
 @test axisdim(A, Axis{:x}) == axisdim(A, Axis{:x}()) == 1
 @test axisdim(A, Axis{:y}) == axisdim(A, Axis{:y}()) == 2


### PR DESCRIPTION
Implements and closes #103

- `AxisArray(A::AxisArray)` is a no-op
- `AxisArray(A::AxisArray, args specifying axis)` wraps `A.data`, rather than A. Furthermore, when axis are missing the default names and indices are taken from A, rather than constructed using `AxisArrays.default_axes`.