### PR TITLE
Allow atvalue indexing in categorical axes

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -249,6 +249,12 @@ function axisindexes(::Type{Categorical}, ax::AbstractVector, idx)
     i == 0 && throw(ArgumentError("index $idx not found"))
     i
 end
+function axisindexes(::Type{Categorical}, ax::AbstractVector, idx::Value)
+    val = idx.val
+    i = findfirst(ax, val)
+    i == 0 && throw(ArgumentError("index $val not found"))
+    i
+end
 # Categorical axes may be indexed by a vector of their elements
 function axisindexes(::Type{Categorical}, ax::AbstractVector, idx::AbstractVector)
     res = findin(ax, idx)

--- a/test/categoricalvector.jl
+++ b/test/categoricalvector.jl
@@ -13,8 +13,11 @@ A = AxisArray(data[idx,:], AxisArrays.CategoricalVector(v[idx]), [:a, :b])
 v = AxisArrays.CategoricalVector(collect([1; 8; 10:15]))
 @test AxisArrays.axistrait(axes(A)[1]) <: AxisArrays.Categorical
 A = AxisArray(reshape(1:16, 8, 2), v, [:a, :b])
+
 @test A[Axis{:row}(AxisArrays.CategoricalVector([15]))] == AxisArray(reshape(A.data[8, :], 1, 2), AxisArrays.CategoricalVector([15]), [:a, :b])
 @test A[Axis{:row}(AxisArrays.CategoricalVector([15])), 1] == AxisArray([A.data[8, 1]], AxisArrays.CategoricalVector([15]))
+@test A[atvalue(15), :] == AxisArray(A.data[8, :], [:a, :b])
+@test A[atvalue(15), 1] == 8
 @test AxisArrays.axistrait(axes(A)[1]) <: AxisArrays.Categorical
 
 # TODO: maybe make this work? Would require removing or modifying Base.getindex(A::AxisArray, idxs::Idx...)


### PR DESCRIPTION
```
julia> using AxisArrays

julia> using AxisArrays: CategoricalVector

julia> A = AxisArray(zeros(3,3), Axis{:a1}(CategoricalVector([1,55,9])), Axis{:a2}([11,22,33]))
2-dimensional AxisArray{Float64,2,...} with axes:
    :a1, [1, 55, 9]
    :a2, [11, 22, 33]
And data, a 3×3 Array{Float64,2}:
 0.0  0.0  0.0
 0.0  0.0  0.0
 0.0  0.0  0.0
```
Previously:
```
julia> A[atvalue(55), atvalue(22)]
ERROR: ArgumentError: index Value(55, tol=0) not found
Stacktrace:
 [1] axisindexes(::Type{AxisArrays.Categorical}, ::AxisArrays.CategoricalVector{Int64,Array{Int64,1}}, ::AxisArrays.Value{Int64}) at /Users/ericdavies/.julia/v0.6/AxisArrays/src/indexing.jl:249
 [2] getindex(::AxisArrays.AxisArray{Float64,2,Array{Float64,2},Tuple{AxisArrays.Axis{:a1,AxisArrays.CategoricalVector{Int64,Array{Int64,1}}},AxisArrays.Axis{:a2,Array{Int64,1}}}}, ::AxisArrays.Value{Int64}, ::AxisArrays.Value{Int64}) at /Users/ericdavies/.julia/v0.6/AxisArrays/src/indexing.jl:98
```
Now:
```
julia> A[atvalue(55), atvalue(22)]
0.0
```