### PR TITLE
conversion and copy of arrays which differ by axis permutations

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -297,7 +297,7 @@ function Base.convert(I::Type{AxisArray{TT, N, AA, AAs}},
                       array::AxisArray{T, N, A, As}
                      )::AxisArray{TT, N, AA, AAs} where {TT, N, AA, AAs, T, A, As}
     perm = indexin(collect(axisnames(I)), collect(axisnames(array)))
-    any(perm .== 0) && throw(ArgumentError("Axes do not match"))
+    any(iszero(x) for x in perm) && throw(ArgumentError("Axes do not match"))
     data = permutedims(convert(AA, array.data), perm)
     AxisArray(data, convert.(collect(AAs.parameters), axes(array)[perm])...)
 end

--- a/src/core.jl
+++ b/src/core.jl
@@ -334,6 +334,16 @@ function Base.copy!(dest::AxisArray{TT, N, AA, AAs},
     dest
 end
 
+"""
+    copy!(dest::AxisArray, daxes::Tuple, src::AxisArray, saxes::Tuple, ignore_axes=false)
+
+Copies a block from one array to a block of another. The tuples identifying the blocks can
+be anything that `view` accepts. Hence it may include axis information.
+"""
+Base.copy!(dest::AxisArray, daxes::Tuple{Axis, Vararg{Axis}},
+           src::AxisArray, saxes::Tuple{Axis, Vararg{Axis}}) =
+    copy!(view(dest, daxes...), view(src, saxes...))
+
 # These methods allow us to preserve the AxisArray under reductions
 # Note that we only extend the following two methods, and then have it
 # dispatch to package-local `reduced_indices` and `reduced_indices0`

--- a/src/core.jl
+++ b/src/core.jl
@@ -296,10 +296,10 @@ Base.convert(::Type{AxisArray{TT, N, AA, As}},
 function Base.convert(I::Type{AxisArray{TT, N, AA, AAs}},
                       array::AxisArray{T, N, A, As}
                      )::AxisArray{TT, N, AA, AAs} where {TT, N, AA, AAs, T, A, As}
-    perm = map(x -> findfirst(y -> typeof(y) <: x, axes(array)),
-               I.parameters[end].parameters)
+    perm = indexin(collect(axisnames(I)), collect(axisnames(array)))
     any(perm .== 0) && throw(ArgumentError("Axes do not match"))
-    AxisArray(permutedims(convert(AA, array), perm), axes(array)[perm])
+    data = permutedims(convert(AA, array.data), perm)
+    AxisArray(data, convert.(collect(AAs.parameters), axes(array)[perm])...)
 end
 
 function Base.copy!(dest::AxisArray{TT, N, AA, As},
@@ -313,9 +313,9 @@ end
 The axes should be the same (name and length) to a permutation. Alternatively, the sizes of
 the two arrays should match.
 """
-Base.copy!(dest::AxisArray{TT, N, AA, AAs},
-           source::AxisArray{T, N, A, As}) where {TT, N, AA, AAs, T, A, As} = begin
-    perm = map(x -> findfirst(y -> y == x, axes(source)), axes(dest))
+function Base.copy!(dest::AxisArray{TT, N, AA, AAs},
+                    source::AxisArray{T, N, A, As}) where {TT, N, AA, AAs, T, A, As}
+    perm = indexin(collect(axisnames(dest)), collect(axisnames(source)))
     if any(perm .== 0)
         size(source) == size(dest) || throw(ArgumentError("Neither axes nor sizes match"))
         copy!(dest.data, source.data)

--- a/src/core.jl
+++ b/src/core.jl
@@ -288,6 +288,20 @@ Base.similar(A::AxisArray, ::Type{S}, ax1::Axis, axs::Axis...) where {S} = simil
     end
 end
 
+Base.convert(::Type{AxisArray{T, N, A, As}},
+             array::AxisArray{T, N, A, As}) where {T, N, A, As} = array
+Base.convert(::Type{AxisArray{TT, N, AA, As}},
+             array::AxisArray{T, N, A, As}) where {TT, N, AA, As, T, A} =
+    AxisArray(convert(AA, array), axes(array))
+function Base.convert(I::Type{AxisArray{TT, N, AA, AAs}},
+                      array::AxisArray{T, N, A, As}
+                     )::AxisArray{TT, N, AA, AAs} where {TT, N, AA, AAs, T, A, As}
+    perm = map(x -> findfirst(y -> typeof(y) <: x, axes(array)),
+               I.parameters[end].parameters)
+    any(perm .== 0) && throw(ArgumentError("Axes do not match"))
+    AxisArray(permutedims(convert(AA, array), perm), axes(array)[perm])
+end
+
 # These methods allow us to preserve the AxisArray under reductions
 # Note that we only extend the following two methods, and then have it
 # dispatch to package-local `reduced_indices` and `reduced_indices0`

--- a/test/core.jl
+++ b/test/core.jl
@@ -86,14 +86,14 @@ A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
 Adense = AxisArray(zeros(Int16, size(A)), axes(A))
 @test typeof(@inferred(convert(typeof(Adense), A))) == typeof(Adense)
 @test axes(convert(typeof(Adense), A)) == axes(A)
-@test all(convert(typeof(Adense), A).data .== A.data)
+@test convert(typeof(Adense), A).data == A.data
 
 # then add a permutation
 perm = [2, 1, 3]
 Aperm = AxisArray(zeros(Int16, size(A)[perm]), axes(A)[perm])
 @test typeof(@inferred(convert(typeof(Aperm), A))) == typeof(Aperm)
 @test axes(convert(typeof(Aperm), A)) == axes(A)[perm]
-@test all(convert(typeof(Aperm), A).data .== permutedims(A.data, perm))
+@test convert(typeof(Aperm), A).data == permutedims(A.data, perm)
 
 # then change the axis indexing as well as the order
 A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
@@ -101,19 +101,19 @@ B = AxisArray(zeros(Int16, size(A)), Axis{:c}(1:2), Axis{:a}(-1:1), Axis{:b}(1:4
 perm = [3, 1, 2]
 @test typeof(@inferred(convert(typeof(B), A))) == typeof(B)
 @test axisnames(convert(typeof(B), A)) == axisnames(A)[perm]
-@test all(convert(typeof(B), A).data .== permutedims(A.data, perm))
+@test convert(typeof(B), A).data == permutedims(A.data, perm)
 
 # copies two arrays
 A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
 B = AxisArray(zeros(Int16, 2, 3, 4), :a, :b, :c)
 @test @inferred(copy!(B, A)) === B
-@test all(copy!(B, A).data .== A.data)
+@test copy!(B, A).data == A.data
 B = AxisArray(zeros(Int16, 3, 2, 4), :b, :a, :c)
 @test @inferred(copy!(B, A)) === B
-@test all(copy!(B, A).data .== permutedims(A.data, (2, 1, 3)))
+@test copy!(B, A).data == permutedims(A.data, (2, 1, 3))
 B = AxisArray(zeros(Int16, 3, 2, 4), Axis{:b}(2:4), Axis{:a}(2:3), Axis{:c}(-1:2))
 @test @inferred(copy!(B, A)) === B
-@test all(copy!(B, A).data .== permutedims(A.data, (2, 1, 3)))
+@test copy!(B, A).data == permutedims(A.data, (2, 1, 3))
 B = AxisArray(zeros(Int16, 2, 3, 4))
 @test_throws ArgumentError copy!(B, A)
 @test_throws ArgumentError copy!(B, A, false)

--- a/test/core.jl
+++ b/test/core.jl
@@ -115,8 +115,10 @@ B = AxisArray(zeros(Int16, 3, 2, 4), Axis{:b}(2:4), Axis{:a}(2:3), Axis{:c}(-1:2
 @test @inferred(copy!(B, A)) === B
 @test all(copy!(B, A).data .== permutedims(A.data, (2, 1, 3)))
 B = AxisArray(zeros(Int16, 2, 3, 4))
-@test @inferred(copy!(B, A)) === B
-@test all(copy!(B, A).data .== A.data)
+@test_throws ArgumentError copy!(B, A)
+@test_throws ArgumentError copy!(B, A, false)
+@test @inferred(copy!(B, A, true)) === B
+@test copy!(B, A, true).data == A.data
 
 
 # make sure array types match

--- a/test/core.jl
+++ b/test/core.jl
@@ -88,12 +88,20 @@ Adense = AxisArray(zeros(Int16, size(A)), axes(A))
 @test axes(convert(typeof(Adense), A)) == axes(A)
 @test all(convert(typeof(Adense), A).data .== A.data)
 
-# finally add a permutation
+# then add a permutation
 perm = [2, 1, 3]
 Aperm = AxisArray(zeros(Int16, size(A)[perm]), axes(A)[perm])
 @test typeof(@inferred(convert(typeof(Aperm), A))) == typeof(Aperm)
 @test axes(convert(typeof(Aperm), A)) == axes(A)[perm]
 @test all(convert(typeof(Aperm), A).data .== permutedims(A.data, perm))
+
+# then change the axis indexing as well as the order
+A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
+B = AxisArray(zeros(Int16, size(A)), Axis{:c}(1:2), Axis{:a}(-1:1), Axis{:b}(1:4))
+perm = [3, 1, 2]
+@test typeof(@inferred(convert(typeof(B), A))) == typeof(B)
+@test axisnames(convert(typeof(B), A)) == axisnames(A)[perm]
+@test all(convert(typeof(B), A).data .== permutedims(A.data, perm))
 
 # copies two arrays
 A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
@@ -101,6 +109,9 @@ B = AxisArray(zeros(Int16, 2, 3, 4), :a, :b, :c)
 @test @inferred(copy!(B, A)) === B
 @test all(copy!(B, A).data .== A.data)
 B = AxisArray(zeros(Int16, 3, 2, 4), :b, :a, :c)
+@test @inferred(copy!(B, A)) === B
+@test all(copy!(B, A).data .== permutedims(A.data, (2, 1, 3)))
+B = AxisArray(zeros(Int16, 3, 2, 4), Axis{:b}(2:4), Axis{:a}(2:3), Axis{:c}(-1:2))
 @test @inferred(copy!(B, A)) === B
 @test all(copy!(B, A).data .== permutedims(A.data, (2, 1, 3)))
 B = AxisArray(zeros(Int16, 2, 3, 4))
@@ -112,7 +123,7 @@ B = AxisArray(zeros(Int16, 2, 3, 4))
 Anomatch = AxisArray(zeros(Int16, size(A)), Base.front(axes(A)))
 @test_throws ArgumentError convert(typeof(Anomatch), A)
 Anomatch = AxisArray(zeros(Int16, size(A)), Axis{:a}((:a, :b)), axes(A)[2:end]...)
-@test_throws ArgumentError convert(typeof(Anomatch), A)
+@test_throws MethodError convert(typeof(Anomatch), A)
 
 ## Test constructors
 # No axis or time args

--- a/test/core.jl
+++ b/test/core.jl
@@ -77,6 +77,30 @@ H = similar(A, Float64, 1,1,1)
 # Size
 @test size(A, 1) == size(A, Axis{1}) == size(A, Axis{:row}) == size(A, Axis{:row}())
 
+# Convert between arrays with similar axes
+# first the no-op kind
+A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
+@test @inferred(convert(typeof(A), A)) === A
+
+# then change the underlying array type, retaining the axes
+Adense = AxisArray(zeros(Int16, size(A)), axes(A))
+@test typeof(@inferred(convert(typeof(Adense), A))) == typeof(Adense)
+@test axes(convert(typeof(Adense), A)) == axes(A)
+@test all(convert(typeof(Adense), A).data .== A.data)
+
+# finally add a permutation
+perm = [2, 1, 3]
+Aperm = AxisArray(zeros(Int16, size(A)[perm]), axes(A)[perm])
+@test typeof(@inferred(convert(typeof(Aperm), A))) == typeof(Aperm)
+@test axes(convert(typeof(Aperm), A)) == axes(A)[perm]
+@test all(convert(typeof(Aperm), A).data .== permutedims(A.data, perm))
+
+# make sure array types match
+Anomatch = AxisArray(zeros(Int16, size(A)), Base.front(axes(A)))
+@test_throws ArgumentError convert(typeof(Anomatch), A)
+Anomatch = AxisArray(zeros(Int16, size(A)), Axis{:a}((:a, :b)), axes(A)[2:end]...)
+@test_throws ArgumentError convert(typeof(Anomatch), A)
+
 ## Test constructors
 # No axis or time args
 A = AxisArray(1:3)

--- a/test/core.jl
+++ b/test/core.jl
@@ -108,12 +108,23 @@ A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
 B = AxisArray(zeros(Int16, 2, 3, 4), :a, :b, :c)
 @test @inferred(copy!(B, A)) === B
 @test copy!(B, A).data == A.data
+
 B = AxisArray(zeros(Int16, 3, 2, 4), :b, :a, :c)
 @test @inferred(copy!(B, A)) === B
 @test copy!(B, A).data == permutedims(A.data, (2, 1, 3))
+
 B = AxisArray(zeros(Int16, 3, 2, 4), Axis{:b}(2:4), Axis{:a}(2:3), Axis{:c}(-1:2))
 @test @inferred(copy!(B, A)) === B
 @test copy!(B, A).data == permutedims(A.data, (2, 1, 3))
+
+B = zeros(A)
+Bindices = (Axis{:a}(atvalue(1)), Axis{:c}(2:3), Axis{:b}(1:2))
+Aindices = (Axis{:b}(1:2), Axis{:a}(atvalue(2)), Axis{:c}(1:2))
+@inferred(copy!(B, Bindices, A, Aindices))
+@test B[Bindices...] == A[Aindices...] # checks the bits that were copied
+fill!(view(B, Bindices...), 0) # This and next line check the bits that were not copied
+@test iszero(B)
+
 B = AxisArray(zeros(Int16, 2, 3, 4))
 @test_throws ArgumentError copy!(B, A)
 @test_throws ArgumentError copy!(B, A, false)

--- a/test/core.jl
+++ b/test/core.jl
@@ -95,6 +95,19 @@ Aperm = AxisArray(zeros(Int16, size(A)[perm]), axes(A)[perm])
 @test axes(convert(typeof(Aperm), A)) == axes(A)[perm]
 @test all(convert(typeof(Aperm), A).data .== permutedims(A.data, perm))
 
+# copies two arrays
+A = AxisArray(reshape(1:24, 2, 3, 4), :a, :b, :c)
+B = AxisArray(zeros(Int16, 2, 3, 4), :a, :b, :c)
+@test @inferred(copy!(B, A)) === B
+@test all(copy!(B, A).data .== A.data)
+B = AxisArray(zeros(Int16, 3, 2, 4), :b, :a, :c)
+@test @inferred(copy!(B, A)) === B
+@test all(copy!(B, A).data .== permutedims(A.data, (2, 1, 3)))
+B = AxisArray(zeros(Int16, 2, 3, 4))
+@test @inferred(copy!(B, A)) === B
+@test all(copy!(B, A).data .== A.data)
+
+
 # make sure array types match
 Anomatch = AxisArray(zeros(Int16, size(A)), Base.front(axes(A)))
 @test_throws ArgumentError convert(typeof(Anomatch), A)


### PR DESCRIPTION
This PR addresses the problem of converting or copying between arrays that address essentially the same data, but with different in-memory order. In other words, when two arrays share the same axis but in different order `axisnames(A) == (:a, :b, :c)` vs `axisnames(B) == (:b, :a, :c)`.

This can be useful for instance when going from array of structures to structure of arrays idioms.