### PR TITLE
Add and test for a better boundserror when performing implicit value indexing

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -186,7 +186,11 @@ axisindexes(::Type{Dimensional}, ax::AbstractVector, idx::Real) =
 function axisindexes(::Type{Dimensional}, ax::AbstractVector, idx)
     idxs = searchsorted(ax, ClosedInterval(idx,idx))
     length(idxs) > 1 && error("more than one datapoint lies on axis value $idx; use an interval to return all values")
-    idxs[1]
+    if length(idxs) == 1
+        idxs[1]
+    else
+        throw(BoundsError(ax, idx))
+    end
 end
 # Dimensional axes may always be indexed by value if in a Value type wrapper.
 function axisindexes(::Type{Dimensional}, ax::AbstractVector, idx::TolValue)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using AxisArrays
+using Base.Dates
 using Base.Test
 import IterTools
 


### PR DESCRIPTION
Previously a `A[:, DateTime(2016, 1, 2, 3)]` call which would throw a `BoundsError` from `axisindexes` would throw `BoundsError(4:3, 1)` instead of something referencing the input. 

If anyone has better ideas for testing the contents of an error struct than [this](https://github.com/JuliaArrays/AxisArrays.jl/compare/master...invenia:dimensional-bounds-error?expand=1#diff-a80db444078918d990a564c113253606R192) I'm more than happy to change it.