### PR TITLE
Use categorical indexing behaviour by default for unknown array eltypes

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -539,7 +539,7 @@ axistrait(::Type{Axis{name,T}}) where {name,T} = axistrait(T)
 axistrait(::Type{T}) where {T<:AbstractVector} = _axistrait_el(eltype(T))
 _axistrait_el(::Type{<:Union{Number, Dates.AbstractTime}}) = Dimensional
 _axistrait_el(::Type{<:Union{Symbol, AbstractString}}) = Categorical
-_axistrait_el(::Type{T}) where {T} = Unsupported
+_axistrait_el(::Type{T}) where {T} = Categorical
 
 checkaxis(ax::Axis) = checkaxis(ax.val)
 checkaxis(ax) = checkaxis(axistrait(ax), ax)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -26,6 +26,9 @@ Base.start(::Value) = false
 Base.next(x::Value, state) = (x, true)
 Base.done(x::Value, state) = state
 
+# Values have the indexing trait of their wrapped type
+_axistrait_el(::Type{<:Value{T}}) where {T} = _axistrait_el(T)
+
 # How to show Value objects (e.g. in a BoundsError)
 Base.show(io::IO, v::TolValue) =
     print(io, string("TolValue(", v.val, ", tol=", v.tol, ")"))

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -193,6 +193,13 @@ acc = zeros(Int, 4, 1, 2)
 Base.mapreducedim!(x->x>5, +, acc, A3)
 @test acc == reshape([1 3; 2 3; 2 3; 2 3], 4, 1, 2)
 
+# Value axistraits
+@testset for typ in (IL.IntLike, Complex{Float32}, DateTime, String, Symbol, Int)
+    @test AxisArrays.axistrait(Axis{:foo, Vector{AxisArrays.ExactValue{typ}}}) ===
+        AxisArrays.axistrait(Axis{:foo, Vector{AxisArrays.TolValue{typ}}}) ===
+        AxisArrays.axistrait(Axis{:bar, Vector{typ}})
+end
+
 # Indexing by value using `atvalue`
 A = AxisArray([1 2; 3 4], Axis{:x}([1.0,4.0]), Axis{:y}([2.0,6.1]))
 @test @inferred(A[atvalue(1.0)]) == @inferred(A[atvalue(1.0), :]) == [1,2]

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -242,6 +242,16 @@ A = AxisArray([1 2; 3 4], Axis{:x}([:a, :b]), Axis{:y}(["c", "d"]))
 @test @inferred(A[Axis{:x}(atvalue(:b))]) == [3,4]
 @test @inferred(A[Axis{:y}(atvalue("d"))]) == [2,4]
 
+# Index by mystery types categorically
+struct Foo
+    x
+end
+A = AxisArray(1:10, Axis{:x}(map(Foo, 1:10)))
+@test A[map(Foo, 3:6)] == collect(3:6)
+@test_throws ArgumentError A[map(Foo, 3:11)]
+@test A[Foo(4)] == 4
+@test_throws ArgumentError A[Foo(0)]
+
 # Test using dates
 using Base.Dates: Day, Month
 A = AxisArray(1:365, Date(2017,1,1):Date(2017,12,31))


### PR DESCRIPTION
Previously, every unknown eltype (not a subtype of Number, AbstractTime, etc.) would require a new `axistrait` definition, or wrapping in a SortedVector or CategoricalVector type.
Now, the default behaviour for indexing using an AbstractArray axis is Categorical, which requires only equality and not `isless`. 

I also made arrays of Value types have the axistrait of either Categorical or Dimensional depending on the type they wrap, which maintains existing tested behaviour. 