### PR TITLE
Make searchsorted on ClosedInterval generic over AbstractVector

### DIFF
--- a/src/search.jl
+++ b/src/search.jl
@@ -16,7 +16,7 @@ function searchsortednearest(vec::AbstractVector, x)
     return idx
 end
 # Base only specializes searching ranges by Numbers; so optimize for Intervals
-function Base.searchsorted(a::Range, I::ClosedInterval)
+function Base.searchsorted(a::AbstractVector, I::ClosedInterval)
     searchsortedfirst(a, I.left):searchsortedlast(a, I.right)
 end
 

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -108,6 +108,12 @@ A = AxisArray(reshape(1:32, 2, 2, 2, 2, 2), .1:.1:.2, .1:.1:.2, .1:.1:.2, [:a, :
 @test A[ClosedInterval(.15, .25), ClosedInterval(.05, .15), ClosedInterval(.15, .25), :a] == A.data[2:2, 1:1, 2:2, 1, :]
 @test A[Axis{:dim_5}(2)] == A.data[:, :, :, :, 2]
 
+# allow SortedVector to force Dimensional behaviour when comparison is possible
+A = AxisArray([1,3,2], Axis{:a}(SortedVector(["one", "three", "two"])))
+@test A["three"] == 3
+@test A["three".."three"] == A["thra".."thro"] == AxisArray([3], Axis{:a}(SortedVector(["three"])))
+@test A["a".."z"] == A
+
 # Test vectors
 v = AxisArray(collect(.1:.1:10.0), .1:.1:10.0)
 @test v[Colon()] == v


### PR DESCRIPTION
Previously, `searchsorted` with `ClosedInterval` as the index could only search a `Range`.
But, since `searchsorted(first|last)` works for any type with an ordering, we can extend `searchsorted` to search any `AbstractVector`.

This allows forcing `Dimensional` behaviour with `SortedVector` the same way one can force `Categorical` behaviour with `CategoricalVector`. 

```julia
julia> A = AxisArray([1,3,2], Axis{:a}(SortedVector(["one", "three", "two"])))
1-dimensional AxisArray{Int64,1,...} with axes:
    :a, String["one", "three", "two"]
And data, a 3-element Array{Int64,1}:
 1
 3
 2
```

Before:
```julia
julia> A["three"]
ERROR: MethodError: no method matching isless(::String, ::IntervalSets.ClosedInterval{String})
Closest candidates are:
  isless(::AbstractString, ::AbstractString) at strings/basic.jl:124
  isless(::IntervalSets.ClosedInterval, ::IntervalSets.ClosedInterval) at /Users/ericdavies/.julia/v0.6/AxisArrays/src/intervals.jl:26
  isless(::Union{Base.Dates.AbstractTime, Number}, ::IntervalSets.ClosedInterval) at /Users/ericdavies/.julia/v0.6/AxisArrays/src/intervals.jl:53
Stacktrace:
 [1] searchsorted(::AxisArrays.SortedVector{String}, ::IntervalSets.ClosedInterval{String}, ::Int64, ::Int64, ::Base.Order.ForwardOrdering) at ./sort.jl:139
 [2] searchsorted(::AxisArrays.SortedVector{String}, ::IntervalSets.ClosedInterval{String}, ::Base.Order.ForwardOrdering) at ./sort.jl:213
 [3] axisindexes(::Type{AxisArrays.Dimensional}, ::AxisArrays.SortedVector{String}, ::String) at /Users/ericdavies/.julia/v0.6/AxisArrays/src/indexing.jl:190
 [4] getindex(::AxisArrays.AxisArray{Int64,1,Array{Int64,1},Tuple{AxisArrays.Axis{:a,AxisArrays.SortedVector{String}}}}, ::String) at /Users/ericdavies/.julia/v0.6/AxisArrays/src/indexing.jl:123
```
After:
```julia
julia> A["three"]
3

julia> A["three".."three"]
1-dimensional AxisArray{Int64,1,...} with axes:
    :a, String["three"]
And data, a 1-element Array{Int64,1}:
 3

julia> A["thra".."thro"]
1-dimensional AxisArray{Int64,1,...} with axes:
    :a, String["three"]
And data, a 1-element Array{Int64,1}:
 3

julia> A["a".."a"]
1-dimensional AxisArray{Int64,1,...} with axes:
    :a, String[]
And data, a 0-element Array{Int64,1}

julia> A["a".."z"]
1-dimensional AxisArray{Int64,1,...} with axes:
    :a, String["one", "three", "two"]
And data, a 3-element Array{Int64,1}:
 1
 3
 2
```
