### PR TITLE
Fix error in nightly with Dates

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.6
 IntervalSets 0.1
 IterTools
 RangeArrays
+Compat 0.33.0

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -6,6 +6,9 @@ using Base: tail
 import Base.Iterators: repeated
 using RangeArrays, IntervalSets
 using IterTools
+using Compat
+using Compat.Dates
+using Compat: AbstractRange
 
 export AxisArray, Axis, axisnames, axisvalues, axisdim, axes, atindex, atvalue, collapse
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -506,8 +506,8 @@ axes(A::AbstractArray, dim::Int) = default_axes(A)[dim]
 
 Returns the axis parameters for an AxisArray.
 """
-axisparams(::AxisArray{T,N,D,Ax}) where {T,N,D,Ax} = (Ax.parameters...)
-axisparams(::Type{AxisArray{T,N,D,Ax}}) where {T,N,D,Ax} = (Ax.parameters...)
+axisparams(::AxisArray{T,N,D,Ax}) where {T,N,D,Ax} = (Ax.parameters...,)
+axisparams(::Type{AxisArray{T,N,D,Ax}}) where {T,N,D,Ax} = (Ax.parameters...,)
 
 ### Axis traits ###
 abstract type AxisTrait end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -252,10 +252,10 @@ axisindexes(::Type{Dimensional}, ax::AbstractVector, idx::ClosedInterval) = sear
 # time, we want `A[interval] == vec(A[interval + [0]])`. To make these
 # computations as similar as possible, we use a phony range of the form
 # `step(ax):step(ax):step(ax)` in order to search for the interval.
-phony_range(r::Range) = step(r):step(r):step(r)
+phony_range(r::AbstractRange) = step(r):step(r):step(r)
 phony_range(r::AbstractUnitRange) = step(r):step(r)
 phony_range(r::StepRangeLen) = StepRangeLen(r.step, r.step, 1)
-function relativewindow(r::Range, x::ClosedInterval)
+function relativewindow(r::AbstractRange, x::ClosedInterval)
     pr = phony_range(r)
     idxs = Extrapolated.searchsorted(pr, x)
     vals = Extrapolated.getindex(pr, idxs)
@@ -263,7 +263,7 @@ function relativewindow(r::Range, x::ClosedInterval)
 end
 
 axisindexes(::Type{Dimensional}, ax::AbstractVector, idx::RepeatedInterval) = error("repeated intervals might select a varying number of elements for non-range axes; use a repeated Range of indices instead")
-function axisindexes(::Type{Dimensional}, ax::Range, idx::RepeatedInterval)
+function axisindexes(::Type{Dimensional}, ax::AbstractRange, idx::RepeatedInterval)
     idxs, vals = relativewindow(ax, idx.window)
     offsets = [Extrapolated.searchsortednearest(ax, offset) for offset in idx.offsets]
     AxisArray(RepeatedRangeMatrix(idxs, offsets), Axis{:sub}(vals), Axis{:rep}(Extrapolated.getindex(ax, offsets)))
@@ -271,12 +271,13 @@ end
 
 # We also have special datatypes to represent intervals about indices
 axisindexes(::Type{Dimensional}, ax::AbstractVector, idx::IntervalAtIndex) = searchsorted(ax, idx.window + ax[idx.index])
-function axisindexes(::Type{Dimensional}, ax::Range, idx::IntervalAtIndex)
+function axisindexes(::Type{Dimensional}, ax::AbstractRange, idx::IntervalAtIndex)
     idxs, vals = relativewindow(ax, idx.window)
     AxisArray(idxs + idx.index, Axis{:sub}(vals))
 end
 axisindexes(::Type{Dimensional}, ax::AbstractVector, idx::RepeatedIntervalAtIndexes) = error("repeated intervals might select a varying number of elements for non-range axes; use a repeated Range of indices instead")
-function axisindexes(::Type{Dimensional}, ax::Range, idx::RepeatedIntervalAtIndexes)
+function axisindexes(::Type{Dimensional}, ax::AbstractRange,
+                     idx::RepeatedIntervalAtIndexes)
     idxs, vals = relativewindow(ax, idx.window)
     AxisArray(RepeatedRangeMatrix(idxs, idx.indexes), Axis{:sub}(vals), Axis{:rep}(ax[idx.indexes]))
 end

--- a/src/search.jl
+++ b/src/search.jl
@@ -16,7 +16,7 @@ function searchsortednearest(vec::AbstractVector, x)
     return idx
 end
 # Base only specializes searching ranges by Numbers; so optimize for Intervals
-function Base.searchsorted(a::Range, I::ClosedInterval)
+function Base.searchsorted(a::AbstractRange, I::ClosedInterval)
     searchsortedfirst(a, I.left):searchsortedlast(a, I.right)
 end
 
@@ -27,8 +27,9 @@ sufficient since it can be turned off by `--check-bounds=yes`.
 """
 module Extrapolated
 using ..ClosedInterval
+using Compat: AbstractRange
 
-function searchsortednearest(vec::Range, x)
+function searchsortednearest(vec::AbstractRange, x)
     idx = searchsortedfirst(vec, x) # Returns the first idx | vec[idx] >= x
     if (getindex(vec, idx) - x) > (x - getindex(vec, idx-1))
         idx -= 1 # The previous element is closer
@@ -37,25 +38,25 @@ function searchsortednearest(vec::Range, x)
 end
 
 """
-    searchsorted(a::Range, I::ClosedInterval)
+    searchsorted(a::AbstractRange, I::ClosedInterval)
 
 Return the indices of the range that fall within an interval without checking
 bounds, possibly extrapolating outside the range if needed.
 """
-function searchsorted(a::Range, I::ClosedInterval)
+function searchsorted(a::AbstractRange, I::ClosedInterval)
     searchsortedfirst(a, I.left):searchsortedlast(a, I.right)
 end
 
 # When running with `--check-bounds=yes` (like on Travis), the bounds-check isn't elided
-@inline function getindex(v::Range{T}, i::Integer) where T
+@inline function getindex(v::AbstractRange{T}, i::Integer) where T
     convert(T, first(v) + (i-1)*step(v))
 end
-@inline function getindex(r::Range, s::Range{<:Integer})
+@inline function getindex(r::AbstractRange, s::AbstractRange{<:Integer})
     f = first(r)
     st = oftype(f, f + (first(s)-1)*step(r))
     range(st, step(r)*step(s), length(s))
 end
-getindex(r::Range, I::Array) = [getindex(r, i) for i in I]
+getindex(r::AbstractRange, I::Array) = [getindex(r, i) for i in I]
 @inline getindex(r::StepRangeLen, i::Integer) = Base.unsafe_getindex(r, i)
 @inline function getindex(r::StepRangeLen, s::AbstractUnitRange)
     soffset = 1 + (r.offset - first(s))
@@ -68,29 +69,29 @@ getindex(r::Range, I::Array) = [getindex(r, i) for i in I]
     end
 end
 
-function searchsortedlast(a::Range, x)
+function searchsortedlast(a::AbstractRange, x)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     n = round(Integer,(x-first(a))/step(a))+1
     isless(x, getindex(a, n)) ? n-1 : n
 end
-function searchsortedfirst(a::Range, x)
+function searchsortedfirst(a::AbstractRange, x)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     n = round(Integer,(x-first(a))/step(a))+1
     isless(getindex(a, n), x) ? n+1 : n
 end
-function searchsortedlast(a::Range{<:Integer}, x)
+function searchsortedlast(a::AbstractRange{<:Integer}, x)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     fld(floor(Integer,x)-first(a),step(a))+1
 end
-function searchsortedfirst(a::Range{<:Integer}, x)
+function searchsortedfirst(a::AbstractRange{<:Integer}, x)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     -fld(floor(Integer,-x)+first(a),step(a))+1
 end
-function searchsortedfirst(a::Range{<:Integer}, x::Unsigned)
+function searchsortedfirst(a::AbstractRange{<:Integer}, x::Unsigned)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     -fld(first(a)-signed(x),step(a))+1
 end
-function searchsortedlast(a::Range{<:Integer}, x::Unsigned)
+function searchsortedlast(a::AbstractRange{<:Integer}, x::Unsigned)
     step(a) == 0 && throw(ArgumentError("ranges with a zero step are unsupported"))
     fld(signed(x)-first(a),step(a))+1
 end


### PR DESCRIPTION
Some new warnings and one error have arisen in 0.7/nightly which break AxisArrays. This fixes them:
- Fix error with 0.7 on Base.Dates - deprecation warning breaks use of Dates.AbstractTime
- Fix warnings with use of Range instead of AbstractRange
- Fix deprecated use of (x...) to (x...,)

Note that there are still some errors in the nightly tests (I'm not sure how to fix them), but there are no longer errors in `using AxisArrays` which was breaking my package!