### PR TITLE
WIP: Implement broadcasting with AxisArrays on Julia 0.7

### DIFF
--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -22,5 +22,8 @@ include("indexing.jl")
 include("sortedvector.jl")
 include("categoricalvector.jl")
 include("combine.jl")
+@static if VERSION >= v"0.7.0-DEV.2638"
+    include("broadcast.jl")
+end
 
 end

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -1,0 +1,51 @@
+Base.BroadcastStyle(::Type{<:AxisArray}) = Broadcast.ArrayStyle{AxisArray}()
+
+# Hijack broadcasting after determining style
+function Base.broadcast(f, ::Broadcast.ArrayStyle{AxisArray}, ::Nothing, ::Nothing, As...)
+    # We need to make sure we can combine indices of only the AxisArrays before attempting
+    # broadcasting. The total broadcasting operation may include other AbstractArrays.
+    # We demand that for a given dimension, the axes values and names must match
+    # as implemented, this demands exact matching of axes (even floating point nums).
+    axesAs = Broadcast.combine_indices(axarrs(As)...)
+
+    # Obtain the underlying data and find the result indices if we were to
+    # broadcast all arrays without axis info.
+    Bs = data(As)
+    indicesBs = Broadcast.combine_indices(Bs...)
+
+    # Broadcast using the underlying data
+    broadcasted = broadcast(f, Bs...)
+
+    defaxesBs = default_axes(broadcasted)
+    axesBs = broadcax(axesAs, defaxesBs)
+    return AxisArray(broadcasted, axesBs)
+end
+
+broadcax(axes::Tuple, defaxes::Tuple) =
+    (broadcax1(axes[1], defaxes[1]), broadcax(tail(axes), tail(defaxes))...)
+broadcax(axes::Tuple{}, defaxes::Tuple) = ()
+broadcax1(::Tuple{}, x) = ()
+function broadcax1(axA::Axis, axB::Axis)
+    axAname, axAvalues = axisname(axA), axisvalues(axA)[1]
+    axAname != axisname(axB) && return axA
+    if typeof(axAvalues) <: Base.OneTo
+        # We believe this was a default axis, not just an axis that happened to
+        # have the default name
+        return typeof(axA)(Base.OneTo(length(axB)))
+    else
+        error("axis values did not match.")
+    end
+end
+
+# Compares the value indices and axis names (note: AxisArrays.axes, not Base.axes)
+Broadcast.broadcast_indices(::Broadcast.ArrayStyle{AxisArray}, A) = axes(A)
+
+# Helper functions
+# Given a tuple `A`, return a tuple containing only the AxisArrays in `A`
+axarrs(A::Tuple{AxisArray, Vararg}) = (A[1], axarrs(Base.tail(A))...)
+axarrs(A::Tuple{Any, Vararg}) = axarrs(Base.tail(A))
+axarrs(A::Tuple{}) = ()
+
+data(A::Tuple{AxisArray,Vararg}) = (A[1].data, data(Base.tail(A))...)
+data(A::Tuple{Any,Vararg}) = (A[1], data(Base.tail(A))...)
+data(A::Tuple{}) = ()

--- a/test/broadcast.jl
+++ b/test/broadcast.jl
@@ -1,0 +1,144 @@
+A0 = [1,2,3]
+A  = AxisArray(A0, Axis{:abc}([1.0, 2.0, 3.0]))
+A1 = AxisArray(A0, Axis{:def}([1.0, 2.0, 3.0]))
+A2 = AxisArray(A0, Axis{:abc}([1.0, 2.0, 3.0+eps(3.0)]))
+
+B0 = [1 2 3]
+B  = AxisArray(B0, Axis{:row}(Base.OneTo(1)), Axis{:def}([1.3, 2.4, 36]))
+B1 = AxisArray(B0, Axis{:row}(Base.OneTo(1)),  Axis{:abc}([1.0, 2.0, 3.0]))
+B2 = AxisArray(B0, Axis{:abc}(Base.OneTo(1)), Axis{:def}([1.3, 2.4, 36]))
+
+C0 = reshape([10])
+C  = AxisArray(C0)
+
+D0 = ones(Complex, 3, 3)
+D  = AxisArray(D0, Axis{:abc}([1.0, 2.0, 3.0]), Axis{:def}([1.3, 2.4, 36]))
+D1 = AxisArray(D0, Axis{:abc}([1.0, 2.0, 3.0+eps(3.0)]), Axis{:def}([1.3, 2.4, 36]))
+D2 = AxisArray(D0, Axis{:row}(Base.OneTo(3)), Axis{:def}([1.3, 2.4, 36]))
+D3 = AxisArray(D0, Axis{:abc}([1.0, 2.0, 3.1]), Axis{:def}([1.3, 2.4, 36]))
+
+# AxisArray 0-d + number
+@test (C .+ 1) isa AxisArray
+@test @inferred(C .+ 1).data == reshape([11])
+@test AxisArrays.axes(C .+ 1) == ()
+@test (1 .+ C) isa AxisArray
+@test @inferred(1 .+ C).data == reshape([11])
+@test AxisArrays.axes(1 .+ C) == ()
+
+# AxisArray vector + number
+@test (A .+ 1) isa AxisArray
+@test @inferred(A .+ 1).data == [2,3,4]
+@test AxisArrays.axes(A .+ 1)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test (1 .+ A) isa AxisArray
+@test @inferred(1 .+ A).data == [2,3,4]
+@test AxisArrays.axes(1 .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+
+# AxisArray row-vector + number...
+# AxisArray matrix + number...
+# AxisArray higher-d + number...
+
+# AxisArray 0-d + AxisArray 0-d
+@test (C .+ C) isa AxisArray
+@test @inferred(C .+ C).data == reshape([20])
+@test AxisArrays.axes(C .+ C) == ()
+
+# AxisArray 0-d + non-AxisArray 0-d
+@test (C0 .+ C) isa AxisArray
+@test @inferred(C0 .+ C).data == reshape([20])
+@test AxisArrays.axes(C0 .+ C) == ()
+@test (C .+ C0) isa AxisArray
+@test @inferred(C .+ C0).data == reshape([20])
+@test AxisArrays.axes(C .+ C0) == ()
+
+# AxisArray vector + AxisArray 0-d
+@test @inferred(A .+ C).data == [11,12,13]
+@test AxisArrays.axes(A .+ C)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test length(AxisArrays.axes(A .+ C)) == 1
+@test @inferred(C .+ A).data == [11,12,13]
+@test AxisArrays.axes(C .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test length(AxisArrays.axes(C .+ A)) == 1
+
+# AxisArray vector + non-AxisArray 0-d
+@test @inferred(A .+ C0).data == [11,12,13]
+@test AxisArrays.axes(A .+ C0)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test length(AxisArrays.axes(A .+ C0)) == 1
+@test @inferred(C0 .+ A).data == [11,12,13]
+@test AxisArrays.axes(C0 .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test length(AxisArrays.axes(C0 .+ A)) == 1
+
+# AxisArray vector + AxisArray vector
+@test @inferred(A .+ A).data == [2,4,6]
+@test AxisArrays.axes(A .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test length(AxisArrays.axes(A .+ A)) == 1
+@test_throws DimensionMismatch (A.+A1)      # axis name mismatch
+@test_throws DimensionMismatch (A1.+A)
+@test_throws DimensionMismatch (A.+A2)      # axis value mismatch (floating-points count)
+@test_throws DimensionMismatch (A2.+A)
+
+# AxisArray vector + non-AxisArray vector
+@test @inferred(A .+ A0).data == [2,4,6]
+@test AxisArrays.axes(A .+ A0)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test length(AxisArrays.axes(A .+ A0)) == 1
+@test @inferred(A0 .+ A).data == [2,4,6]
+@test AxisArrays.axes(A0 .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test length(AxisArrays.axes(A0 .+ A)) == 1
+
+# AxisArray vector + 1xN AxisArray matrix
+@test_broken @inferred(A .+ B).data == [2 3 4; 3 4 5; 4 5 6]   # output good but axes aren't yet inferred...
+@test length(AxisArrays.axes(A .+ B)) == 2
+@test AxisArrays.axes(A .+ B)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test AxisArrays.axes(A .+ B)[2] == Axis{:def}([1.3, 2.4, 36])
+
+@test_broken @inferred(B .+ A).data == [2 3 4; 3 4 5; 4 5 6]   # output good but axes aren't yet inferred...
+@test length(AxisArrays.axes(B .+ A)) == 2
+@test AxisArrays.axes(B .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test AxisArrays.axes(B .+ A)[2] == Axis{:def}([1.3, 2.4, 36])
+
+@test_throws ArgumentError (A.+B1)  # axis names don't match
+@test_throws ArgumentError (B1.+A)
+@test_broken @test_throws DimensionMismatch (A.+B2)
+@test_broken @test_throws DimensionMismatch (B2.+A)
+
+# AxisArray vector + 1xN non-AxisArray matrix
+@test @inferred(A.+B0).data == [2 3 4; 3 4 5; 4 5 6]
+@test length(AxisArrays.axes(A .+ B0)) == 2
+@test AxisArrays.axes(A .+ B0)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test AxisArrays.axes(A .+ B0)[2] == Axis{:col}(Base.OneTo(3))
+
+# AxisArray vector + NxN AxisArray matrix
+@test_broken @inferred(A .+ D).data ==
+    [2+0im 2+0im 2+0im;
+     3+0im 3+0im 3+0im;
+     4+0im 4+0im 4+0im] # output good but inference dies
+@test length(AxisArrays.axes(A .+ D)) == 2
+@test AxisArrays.axes(A .+ D)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test AxisArrays.axes(A .+ D)[2] == Axis{:def}([1.3, 2.4, 36])
+@test_broken @inferred(D .+ A).data ==
+    [2+0im 2+0im 2+0im;
+     3+0im 3+0im 3+0im;
+     4+0im 4+0im 4+0im] # output good but inference dies
+@test length(AxisArrays.axes(D .+ A)) == 2
+@test AxisArrays.axes(D .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test AxisArrays.axes(D .+ A)[2] == Axis{:def}([1.3, 2.4, 36])
+@test_throws DimensionMismatch (A.+D1)
+@test_throws DimensionMismatch (D1.+A)
+@test_throws DimensionMismatch (A.+D2)
+@test_throws DimensionMismatch (D2.+A)
+@test_throws DimensionMismatch (A.+D3)
+@test_throws DimensionMismatch (D3.+A)
+
+# AxisArray vector + NxN non-AxisArray matrix
+@test_broken @inferred(A .+ D0).data ==
+    [2+0im 2+0im 2+0im;
+     3+0im 3+0im 3+0im;
+     4+0im 4+0im 4+0im] # output good but inference dies
+@test length(AxisArrays.axes(A .+ D0)) == 2
+@test AxisArrays.axes(A .+ D0)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test AxisArrays.axes(A .+ D0)[2] == Axis{:col}(Base.OneTo(3))
+@test_broken @inferred(D0 .+ A).data ==
+    [2+0im 2+0im 2+0im;
+     3+0im 3+0im 3+0im;
+     4+0im 4+0im 4+0im] # output good but inference dies
+@test length(AxisArrays.axes(D0 .+ A)) == 2
+@test AxisArrays.axes(D0 .+ A)[1] == Axis{:abc}([1.0, 2.0, 3.0])
+@test AxisArrays.axes(D0 .+ A)[2] == Axis{:col}(Base.OneTo(3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,12 @@ import IterTools
         include("combine.jl")
     end
 
+    @static if VERSION >= v"0.7.0-DEV.2638"
+        @testset "Broadcast" begin
+            include("broadcast.jl")
+        end
+    end
+
     @testset "README" begin
         include("readme.jl")
     end


### PR DESCRIPTION
This PR proposes an implementation of broadcasting for AxisArrays that will be possible using Julia 0.7. I'm getting a bit ahead of myself because not all AxisArrays tests pass on 0.7, and I'm also aware that the new broadcasting API may continue to change (e.g. https://github.com/JuliaLang/julia/pull/25377). However, broadcasting is important enough for how I intend to use AxisArrays that I want to give an early demo, and also want to solicit some feedback before I sink too much time into this approach.

## High-level description

- Broadcasting with AxisArray and scalar args works
- Broadcasting with both AxisArray and AbstractArray args is permitted if the array dimensions are compatible. In other words, we assume the user knows what they are doing, and that the axes are compatible semantically so long as indices match, even if there's no axis name/values available on the generic array.
- Broadcasting with different AxisArrays should require the axis names to match in their corresponding dimensions, and also the axis values need to be the same. No auto alignment.
- Axes that are determined to be "default" are allowed to grow if broadcasting demands a different (larger) output shape.

## Algorithm description

The following discussion relies upon understanding the new broadcasting API described in the interfaces section of the latest Julia docs. Broadcasting is intercepted after styles are combined, but before eltypes and indices are computed.

1. `combine_indices` from any AxisArrays (but not other kinds of arrays) in the broadcasting operation. AxisArray axis names and values are returned from a new `broadcast_indices` method. As currently implemented, this demands exact equality of axis values, so tiny floating-point differences count. This returns a tuple of AxisArrays.Axis that we'll call `axesAs`.

2. Provided that was successful, do broadcasting over all broadcast args using the underlying arrays (`array.data` if `array` is an AxisArray). Call the result `broadcasted`.

3. Compare the axes in `axesAs` with the `default_axes` for `broadcasted` (which is not an AxisArray). We'll call the tuple of default axes `defaxesBs`. Note that `length(axesAs) <= length(defaxesBs)`. Process these two tuples `axesAs` and `defaxesBs` taking pairs of elements `axA`, `axB` from each using `Base.tail`, etc.

3a. If the axis names match, then you need to see if you believe the axis from `axA` was originally a default axis. This PR makes the decision that if you have an axis like `Axis{:row, <:Base.OneTo}`, then it was a default axis. If so, return e.g. `Axis{:row}(Base.OneTo(length(axB))` so that you resize the default axis to match the size required for `broadcasted`. If the values are not from Base.OneTo then it is *not* a default axis, and the arrays cannot be broadcasted.

3b. If the axis names don't match, then there's no need to worry about default axes, just return `axA`.

4. Step 3 yields a tuple of axes. Wrap `broadcasted` into an AxisArray using the axes obtained from step 3. The number of axes you obtain from step 3 may be less than the number of dimensions of `broadcasted`, in which case the AxisArray constructor will use `default_axes` for the remainder.

## Examples

See `test/broadcast.jl`, more tests/examples to come.

## Relation to previous AxisArrays.jl issues and PRs concerning broadcasting

### Issue 128

This PR satisfies what @omus considers an ideal solution in https://github.com/JuliaArrays/AxisArrays.jl/issues/128#issuecomment-340018520 (I've sanitized some deprecation warnings):

```
julia> A = AxisArray([1,2,3], Axis{:asdf}([1.0, 2.0, 5.0]))
3-element AxisArray{Int64,1,Array{Int64,1},Tuple{Axis{:asdf,Array{Float64,1}}}}:
 1
 2
 3

julia> A .* 2
3-element AxisArray{Int64,1,Array{Int64,1},Tuple{Axis{:asdf,Array{Float64,1}}}}:
 2
 4
 6

julia> A .== 2
3-element AxisArray{Bool,1,BitArray{1},Tuple{Axis{:asdf,Array{Float64,1}}}}:
 false
  true
 false
```

### PR 54

This PR also doesn't care about argument order, which was a limitation in PR  https://github.com/JuliaArrays/AxisArrays.jl/pull/54:

```
julia> 1 .+ A
3-element AxisArray{Int64,1,Array{Int64,1},Tuple{Axis{:asdf,Array{Float64,1}}}}:
 2
 3
 4
```

It also doesn't care if the eltypes are Real, another limitation in https://github.com/JuliaArrays/AxisArrays.jl/pull/54:

```
julia> AxisArray([1+im, 2+im]) .+ (3.0+4.5im)
2-element AxisArray{Complex{Float64},1,Array{Complex{Float64},1},Tuple{Axis{:row,Base.OneTo{Int64}}}}:
 4.0 + 5.5im
 5.0 + 5.5im
```

Note that broadcasting is *not* oblivious to the underlying storage order, as mentioned in the high-level description, and there are differing opinions on that [[1]](https://github.com/JuliaArrays/AxisArrays.jl/pull/54#issuecomment-276736820) [[2]](https://github.com/JuliaArrays/AxisArrays.jl/pull/54#issuecomment-289325536). However, this PR is very conservative, in that you can do strictly more with broadcasting while preserving the AxisArray wrapper. If there were another PR that paid no attention to the underlying storage order / did auto alignment, I think you would again have strictly more functionality, for some sense of the word strictly :) I'm not sure how broadcasting should be treated when combining both AxisArrays and AbstractArrays in that case; there you kind of need to pay attention to the storage order.

## Known limitations

1. Not everything is inferable yet, trying to identify why. 

2. Some of the error messages are opaque when broadcasting doesn't work for AxisArray-specific reasons. I don't think this is insurmountable but it would require some more boiler-plate to fix.

3. Axis info can get lost when using wrappers around AxisArrays, like with adjoint:

```
julia> adjoint(A)
1×3 Adjoint{Int64,AxisArray{Int64,1,Array{Int64,1},Tuple{Axis{:abc,Array{Float64,1}}}}}:
 1  2  3

julia> adjoint(A) .+ [10,20,30]
3×3 Array{Int64,2}:
 11  12  13
 21  22  23
 31  32  33

julia> adjoint(A) .+ AxisArray([10,20,30])
3×3 AxisArray{Int64,2,Array{Int64,2},Tuple{Axis{:row,Base.OneTo{Int64}},Axis{:col,Base.OneTo{Int64}}}}:
 11  12  13
 21  22  23
 31  32  33
```

I can work around this but at present it means `A.+A'` doesn't work right. However, if you broadcast a `2-element AxisArray{..,1,...}` with a `1x2 AxisArray{...,2,...}` it works apart from some inference issues I'm trying to sort out (since you avoid the adjoint wrapper).

4. Take a look at `transpose(A)`:

```
julia> transpose(A)
1×3 AxisArray{Int64,2,Transpose{Int64,Array{Int64,1}},Tuple{Axis{:transpose,Base.OneTo{Int64}},Axis{:abc,Array{Float64,1}}}}:
 1  2  3
```

The transpose axis is named :transpose, not :row. As a result, the transpose axis won't be treated as a default axis by my broadcasting algorithm. Maybe that's a good thing, I don't know yet. At first glance I'm surprised transpose(::AxisArray) returns an AxisArray but adjoint(::AxisArray) returns an Adjoint.