### PR TITLE
Fix performance regression by updating findfirst calls for 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,4 @@ julia 0.6
 IntervalSets 0.1
 IterTools
 RangeArrays
-Compat 0.33.0
+Compat 0.61.0

--- a/src/core.jl
+++ b/src/core.jl
@@ -258,8 +258,8 @@ end
 function axisdim(::Type{AxisArray{T,N,D,Ax}}, ::Type{<:Axis{name,S} where S}) where {T,N,D,Ax,name}
     isa(name, Int) && return name <= N ? name : error("axis $name greater than array dimensionality $N")
     names = axisnames(Ax)
-    idx = findfirst(names, name)
-    idx == 0 && error("axis $name not found in array axes $names")
+    idx = Compat.findfirst(isequal(name), names)
+    idx === nothing && error("axis $name not found in array axes $names")
     idx
 end
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -284,14 +284,14 @@ end
 
 # Categorical axes may be indexed by their elements
 function axisindexes(::Type{Categorical}, ax::AbstractVector, idx)
-    i = findfirst(ax, idx)
-    i == 0 && throw(ArgumentError("index $idx not found"))
+    i = Compat.findfirst(isequal(idx), ax)
+    i === nothing && throw(ArgumentError("index $idx not found"))
     i
 end
 function axisindexes(::Type{Categorical}, ax::AbstractVector, idx::Value)
     val = idx.val
-    i = findfirst(ax, val)
-    i == 0 && throw(ArgumentError("index $val not found"))
+    i = Compat.findfirst(isequal(val), ax)
+    i === nothing && throw(ArgumentError("index $val not found"))
     i
 end
 # Categorical axes may be indexed by a vector of their elements


### PR DESCRIPTION
Fixes #136 

## On v0.7

Before: `214.838 μs (210 allocations: 24.53 KiB)`
After: `24.563 ns (1 allocation: 16 bytes)`

## On v0.6

Before: `49.175 ns (1 allocation: 16 bytes)`
After: `42.095 ns (3 allocations: 48 bytes)`