### PR TITLE
Fix type piracy of 0-arg cat

### DIFF
--- a/src/combine.jl
+++ b/src/combine.jl
@@ -13,7 +13,7 @@ sizes(As::AxisArray...) = tuple(zip(map(a -> map(length, Base.axes(a)), As)...).
 matchingdims(As::Tuple{Vararg{AxisArray}}) = all(equalvalued, sizes(As...))
 matchingdimsexcept(As::Tuple{Vararg{AxisArray}}, n::Int) = all(equalvalued, sizes(As...)[[1:n-1; n+1:end]])
 
-Base.cat(As::AxisArray{T}...; dims) where {T} = _cat(dims, As...)
+Base.cat(A1::AxisArray{T}, As::AxisArray{T}...; dims) where {T} = _cat(dims, A1, As...)
 _cat(::Val{n}, As...) where {n} = _cat(n, As...)
 
 @inline function _cat(n::Integer, As...)


### PR DESCRIPTION
Fixes #145 

The existing definition was causing this:
```
julia> cat(dims=1)
0-element Array{Any,1}
```
to become this:
```
julia> cat(dims=1)
ERROR: BoundsError: attempt to access ()
  at index [1]
Stacktrace:
 [1] getindex(::Tuple{}, ::Int64) at ./tuple.jl:24
 [2] _cat at /Users/ericdavies/.julia/dev/AxisArrays/src/combine.jl:20 [inlined]
 [3] #cat#44(::Int64, ::Function) at /Users/ericdavies/.julia/dev/AxisArrays/src/combine.jl:16
 [4] (::getfield(Base, Symbol("#kw##cat")))(::NamedTuple{(:dims,),Tuple{Int64}}, ::typeof(cat)) at ./none:0
 [5] top-level scope at none:0
```