### PR TITLE
Propagate AxisArray copy / view down to taking copies / views of its axes as well

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -20,6 +20,11 @@ atvalue(x) = ExactValue(x)
 
 const Values = AbstractArray{<:Value}
 
+# Trait for describing whether to take views or copies
+abstract type CopyStyle end
+struct Copy <: CopyStyle end
+struct View <: CopyStyle end
+
 # For throwing a BoundsError with a Value index, we need to define the following
 # (note that we could inherit them for free, were Value <: Number)
 Base.iterate(x::Value, state = false) = state ? nothing : (x, true)
@@ -43,21 +48,22 @@ Base.IndexStyle(::Type{AxisArray{T,N,D,Ax}}) where {T,N,D,Ax} = IndexStyle(D)
 Base.eachindex(A::AxisArray) = eachindex(A.data)
 
 """
-    reaxis(A::AxisArray, I...)
+    reaxis(A::AxisArray, copy::Val, I...)
 
 This internal function determines the new set of axes that are constructed upon
-indexing with I.
+indexing with I. The `copy` argument determines whether views or copies of the
+axes are taken.
 """
-reaxis(A::AxisArray, copy::Val, I::Idx...) = _reaxis(make_axes_match(axes(A), I), copy, I)
+reaxis(A::AxisArray, copy::Type{<:CopyStyle}, I::Idx...) = _reaxis(make_axes_match(axes(A), I), copy, I)
 # Linear indexing
-reaxis(A::AxisArray{<:Any,1}, copy::Val, I::AbstractArray{Int}) = _new_axes(A.axes[1], copy, I)
-reaxis(A::AxisArray, copy::Val, I::AbstractArray{Int}) = default_axes(I)
-reaxis(A::AxisArray{<:Any,1}, copy::Val, I::Real) = ()
-reaxis(A::AxisArray, copy::Val, I::Real) = ()
-reaxis(A::AxisArray{<:Any,1}, copy::Val, I::Colon) = _new_axes(A.axes[1], copy, Base.axes(A, 1))
-reaxis(A::AxisArray, copy::Val, I::Colon) = default_axes(Base.OneTo(length(A)))
-reaxis(A::AxisArray{<:Any,1}, copy::Val, I::AbstractArray{Bool}) = _new_axes(A.axes[1], copy, findall(I))
-reaxis(A::AxisArray, copy::Val, I::AbstractArray{Bool}) = default_axes(findall(I))
+reaxis(A::AxisArray{<:Any,1}, copy::Type{<:CopyStyle}, I::AbstractArray{Int}) = _new_axes(A.axes[1], copy, I)
+reaxis(A::AxisArray, copy::Type{<:CopyStyle}, I::AbstractArray{Int}) = default_axes(I)
+reaxis(A::AxisArray{<:Any,1}, copy::Type{<:CopyStyle}, I::Real) = ()
+reaxis(A::AxisArray, copy::Type{<:CopyStyle}, I::Real) = ()
+reaxis(A::AxisArray{<:Any,1}, copy::Type{<:CopyStyle}, I::Colon) = _new_axes(A.axes[1], copy, Base.axes(A, 1))
+reaxis(A::AxisArray, copy::Type{<:CopyStyle}, I::Colon) = default_axes(Base.OneTo(length(A)))
+reaxis(A::AxisArray{<:Any,1},copy::Type{<:CopyStyle}, I::AbstractArray{Bool}) = _new_axes(A.axes[1], copy, findall(I))
+reaxis(A::AxisArray, copy::Type{<:CopyStyle}, I::AbstractArray{Bool}) = default_axes(findall(I))
 
 # Ensure the number of axes matches the number of indexing dimensions
 @inline function make_axes_match(axs, idxs)
@@ -66,24 +72,24 @@ reaxis(A::AxisArray, copy::Val, I::AbstractArray{Bool}) = default_axes(findall(I
 end
 
 # Now we can reaxis without worrying about mismatched axes/indices
-@inline _reaxis(axs::Tuple{}, copy::Val, idxs::Tuple{}) = ()
+@inline _reaxis(axs::Tuple{}, copy::Type{<:CopyStyle}, idxs::Tuple{}) = ()
 # Scalars are dropped
 const ScalarIndex = Union{Real, AbstractArray{<:Any, 0}}
-@inline _reaxis(axs::Tuple, copy::Val, idxs::Tuple{ScalarIndex, Vararg{Any}}) = _reaxis(tail(axs), copy, tail(idxs))
+@inline _reaxis(axs::Tuple, copy::Type{<:CopyStyle}, idxs::Tuple{ScalarIndex, Vararg{Any}}) = _reaxis(tail(axs), copy, tail(idxs))
 # Colon passes straight through
-@inline _reaxis(axs::Tuple, copy::Val, idxs::Tuple{Colon, Vararg{Any}}) = (axs[1], _reaxis(tail(axs), copy, tail(idxs))...)
+@inline _reaxis(axs::Tuple, copy::Type{<:CopyStyle}, idxs::Tuple{Colon, Vararg{Any}}) = (axs[1], _reaxis(tail(axs), copy, tail(idxs))...)
 # But arrays can add or change dimensions and accompanying axis names
-@inline _reaxis(axs::Tuple, copy::Val, idxs::Tuple{AbstractArray, Vararg{Any}}) =
+@inline _reaxis(axs::Tuple, copy::Type{<:CopyStyle}, idxs::Tuple{AbstractArray, Vararg{Any}}) =
     (_new_axes(axs[1], copy, idxs[1])..., _reaxis(tail(axs), copy, tail(idxs))...)
 
 # Vectors simply create new axes with the same name; just subsetted by their value
-@inline _new_axes(ax::Axis{name}, copy::Val{true}, idx::AbstractVector) where {name} = (Axis{name}(ax.val[idx]),)
-@inline _new_axes(ax::Axis{name}, copy::Val{false}, idx::AbstractVector) where {name} = (Axis{name}(view(ax.val, idx)),)
-
-# @inline _new_axes(ax::Axis{name}, copy::Val{false}, idx::AxisArray{T,1,D,Ax}) where {Ax, D, T, name} = _new_axes(ax, copy, idx)
+@inline _new_axes(ax::Axis{name}, ::Type{Copy}, idx::AbstractVector) where {name} = (Axis{name}(ax.val[idx]),)
+@inline _new_axes(ax::Axis{name}, ::Type{View}, idx::AbstractVector) where {name} = (Axis{name}(view(ax.val, idx)),)
 
 # Arrays create multiple axes with _N appended to the axis name containing their indices
-@generated function _new_axes(ax::Axis{name}, copy::Val, idx::AbstractArray{<:Any,N}) where {name, N}
+_new_axes(ax::Axis{name}, ::Type{Copy}, idx::AbstractArray{<:Any, N}) where {name, N} = _new_axes(ax, idx)
+_new_axes(ax::Axis{name}, ::Type{View}, idx::AbstractArray{<:Any, N}) where {name, N} = _new_axes(ax, idx)
+@generated function _new_axes(ax::Axis{name}, idx::AbstractArray{<:Any, N}) where {name, N}
     newaxes = Expr(:tuple)
     for i=1:N
         push!(newaxes.args, :($(Axis{Symbol(name, "_", i)})(Base.axes(idx, $i))))
@@ -92,17 +98,9 @@ const ScalarIndex = Union{Real, AbstractArray{<:Any, 0}}
 end
 
 # And indexing with an AxisArray joins the name and overrides the values
-@generated function _new_axes(ax::Axis{name}, copy::Val{true}, idx::AxisArray{<:Any, N}) where {name,N}
-    newaxes = Expr(:tuple)
-    idxnames = axisnames(idx)
-    for i=1:N
-        push!(newaxes.args, :($(Axis{Symbol(name, "_", idxnames[i])})(idx.axes[$i].val)))
-    end
-    newaxes
-end
-
-# TODO: this is duplicated from the above
-@generated function _new_axes(ax::Axis{name}, copy::Val{false}, idx::AxisArray{<:Any, N}) where {name,N}
+_new_axes(ax::Axis{name}, ::Type{Copy}, idx::AxisArray{<:Any, N}) where {name, N} = _new_axes(ax, idx)
+_new_axes(ax::Axis{name}, ::Type{View}, idx::AxisArray{<:Any, N}) where {name, N} = _new_axes(ax, idx)
+@generated function _new_axes(ax::Axis{name}, idx::AxisArray{<:Any, N}) where {name, N}
     newaxes = Expr(:tuple)
     idxnames = axisnames(idx)
     for i=1:N
@@ -112,19 +110,19 @@ end
 end
 
 @propagate_inbounds function Base.getindex(A::AxisArray, idxs::Idx...)
-    AxisArray(A.data[idxs...], reaxis(A, Val(true), idxs...))
+    AxisArray(A.data[idxs...], reaxis(A, Copy, idxs...))
 end
 
 # To resolve ambiguities, we need several definitions
 using Base: AbstractCartesianIndex
-@propagate_inbounds Base.view(A::AxisArray, idxs::Idx...) = AxisArray(view(A.data, idxs...), reaxis(A, Val(false), idxs...))
+@propagate_inbounds Base.view(A::AxisArray, idxs::Idx...) = AxisArray(view(A.data, idxs...), reaxis(A, View, idxs...))
 
 # Setindex is so much simpler. Just assign it to the data:
 @propagate_inbounds Base.setindex!(A::AxisArray, v, idxs::Idx...) = (A.data[idxs...] = v)
 
 # Logical indexing
 @propagate_inbounds function Base.getindex(A::AxisArray, idx::AbstractArray{Bool})
-    AxisArray(A.data[idx], reaxis(A, Val(true), idx))
+    AxisArray(A.data[idx], reaxis(A, Copy, idx))
 end
 @propagate_inbounds Base.setindex!(A::AxisArray, v, idx::AbstractArray{Bool}) = (A.data[idx] = v)
 


### PR DESCRIPTION
This is my attempt at addressing #147 

All the tests appear to pass. I'm new to Julia and wasn't quite sure on the best way implement this, but doing it via Value types seemed efficient and easy. The only issue was that, in order to resolve the following method ambiguity:

```
  LoadError: MethodError: AxisArrays._new_axes(::Axis{:y,Base.OneTo{Int64}}, ::Val{false}, ::AxisArray{Int64,1,Base.OneTo{Int64},Tuple{Axis{:y,Base.OneTo{Int64}}}}) is ambiguous. Candidates:
    _new_axes(ax::Axis{name,T} where T, copy::Val, idx::AxisArray{#s19,N,D,Ax} where Ax where D where #s19) where {name, N} in AxisArrays at /data/home/jfrigaa/AxisArrays.jl/src/indexing.jl:96
    _new_axes(ax::Axis{name,T} where T, copy::Val{false}, idx::AbstractArray{T,1} where T) where name in AxisArrays at /data/home/jfrigaa/AxisArrays.jl/src/indexing.jl:81
```

I had to duplicate `_new_axes` on line 95 with the `copy` parameter as both `Val{true}` and `Val{false}` (whereas I originally just had the argument as `copy::Val`). I couldn't work out another way to get it to compile, but no doubt someone will be able to suggest a better way to avoid this ambiguity without duplicating code.
