### PR TITLE
WIP: Access the values of an axis with getproperty

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -79,8 +79,21 @@ And data, a 2400001×2 Array{Float64,2}:
 
 ```
 
-AxisArrays behave like regular arrays, but they additionally use the axis
-information to enable all sorts of fancy behaviors. For example, we can specify
+AxisArrays behave like regular arrays, but they carry extra information about
+their axes along with them:
+
+```jldoctest
+julia> A.time
+0.0 s:2.5e-5 s:60.0 s
+
+julia> A.chan
+2-element Array{Symbol,1}:
+ :c1
+ :c2
+
+```
+
+This enables all sorts of fancy indexing behaviors. For example, we can specify
 indices in *any* order, just so long as we annotate them with the axis name:
 
 ```jldoctest

--- a/src/core.jl
+++ b/src/core.jl
@@ -285,6 +285,20 @@ function axisdim(::Type{AxisArray{T,N,D,Ax}}, ::Type{<:Axis{name,S} where S}) wh
     idx
 end
 
+# Access to the values of axes by name
+function Base.getproperty(A::AxisArray, name::Symbol)
+    if name === :data || name === :axes
+        getfield(A, name)
+    else
+        # Other things are axis names
+        getfield(A, :axes)[axisdim(A, Axis{name})].val
+    end
+end
+function Base.propertynames(A::AxisArray, private=false)
+    ns = axisnames(A)
+    private ? (ns..., :data, :axes) : ns
+end
+
 # Base definitions that aren't provided by AbstractArray
 @inline Base.size(A::AxisArray) = size(A.data)
 @inline Base.size(A::AxisArray, Ax::Axis) = size(A.data, axisdim(A, Ax))

--- a/test/core.jl
+++ b/test/core.jl
@@ -167,6 +167,18 @@ A = @inferred(AxisArray(reshape(1:24, 2,3,4),
 @test axisdim(A, Axis{:x}) == axisdim(A, Axis{:x}()) == 1
 @test axisdim(A, Axis{:y}) == axisdim(A, Axis{:y}()) == 2
 @test axisdim(A, Axis{:z}) == axisdim(A, Axis{:z}()) == 3
+# Test that getproperty is fully inferred when a const name is supplied
+let getx(A) = A.x,
+    getz(A) = A.z,
+    getdata(A) = A.data
+    @test @inferred(getx(A)) == A.axes[1].val
+    @test @inferred(getz(A)) == A.axes[3].val
+    @test @inferred(AxisArrays.axes(A)) === A.axes
+    @test @inferred(getdata(A)) === A.data
+end
+@test propertynames(A) == (:x, :y, :z)
+@test propertynames(A, true) == (:x, :y, :z, :data, :axes)
+
 # Test axes
 @test @inferred(AxisArrays.axes(A)) == (Axis{:x}(.1:.1:.2), Axis{:y}(1//10:1//10:3//10), Axis{:z}(["a", "b", "c", "d"]))
 @test @inferred(AxisArrays.axes(A, Axis{:x})) == @inferred(AxisArrays.axes(A, Axis{:x}())) == Axis{:x}(.1:.1:.2)


### PR DESCRIPTION
Here's one possible use for `getproperty` with an `AxisArray`. I'm not yet sure this is a good idea (being an extremely new user of `AxisArrays`), but it seems rather convenient.  [Edit: After a few days of using this I'd say that it's *extremely* convenient.]

A small demo in a signal processing-like context:

```julia
julia> using Unitful, AxisArrays

julia> A = AxisArray(rand(10,2), Axis{:time}((0:9)u"ms"), Axis{:channel}(1:2))
10×2 AxisArray{Float64,2,Array{Float64,2},Tuple{Axis{:time,StepRange{Quantity{Int64,𝐓,Unitful.FreeUnits{(ms,),𝐓,nothing}},Quantity{Int64,𝐓,Unitful.FreeUnits{(ms,),𝐓,nothing}}}},Axis{:channel,UnitRange{Int64}}}}:
 0.891098  0.904336
 0.291428  0.125264
 0.116863  0.639308
 0.217566  0.972434
 0.656042  0.517365
 0.758901  0.723122
 0.856255  0.77854 
 0.671771  0.695505
 0.793823  0.86887 
 0.302142  0.837619

julia> A.time
0 ms:1 ms:9 ms

julia> A.channel
1:2

julia> plot(ustrip.(A.time), A)
# ...
```