### PR TITLE
Fix doctests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 jobs:
   include:
     - stage: deploy
-      julia: 0.7
+      julia: 1.0
       os: linux
       script:
         - julia -e 'import Pkg; Pkg.clone(pwd()); Pkg.build("AxisArrays")'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,6 @@ jobs:
 
 after_success:
 #  - julia -e 'Pkg.add("Unitful")' ?
-  - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+  - if [ $TRAVIS_JULIA_VERSION = "1.0" ] && [ $TRAVIS_OS_NAME = "linux" ]; then
+      julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'
+    fi

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,7 @@ using Documenter, AxisArrays
 
 makedocs(
     modules = [AxisArrays],
+    sitename = "AxisArrays",
 )
 
 deploydocs(

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 ```@meta
 DocTestSetup = quote
-    using AxisArrays, Unitful
+    using AxisArrays, Unitful, Random
     import Unitful: s, ms, µs
     rng = MersenneTwister(123)
     fs = 40000
@@ -33,7 +33,7 @@ Collaboration is welcome! This is still a work-in-progress. See [the roadmap](ht
 
 ```julia
 julia> Pkg.add("AxisArrays")
-julia> using AxisArrays, Unitful
+julia> using AxisArrays, Unitful, Random
 julia> import Unitful: s, ms, µs
 
 julia> rng = MersenneTwister(123) # Seed a random number generator for repeatable examples
@@ -51,7 +51,6 @@ julia> for spk = (sin.(0.8:0.2:8.6) .* [0:0.01:.1; .15:.1:.95; 1:-.05:.05] .* 50
 
 ```jldoctest
 julia> A = AxisArray([y 2y], Axis{:time}(0s:1s/fs:60s), Axis{:chan}([:c1, :c2]))
-
 2-dimensional AxisArray{Float64,2,...} with axes:
     :time, 0.0 s:2.5e-5 s:60.0 s
     :chan, Symbol[:c1, :c2]
@@ -88,18 +87,18 @@ julia> A[Axis{:time}(4)]
 1-dimensional AxisArray{Float64,1,...} with axes:
     :chan, Symbol[:c1, :c2]
 And data, a 2-element Array{Float64,1}:
- 1.37825
- 2.75649
+ 1.378246861221241
+ 2.756493722442482
 
 julia> A[Axis{:chan}(:c2), Axis{:time}(1:5)]
 1-dimensional AxisArray{Float64,1,...} with axes:
     :time, 0.0 s:2.5e-5 s:0.0001 s
 And data, a 5-element Array{Float64,1}:
-  7.14161
- 12.2891
-  6.85591
-  2.75649
- -2.38007
+  7.141607285917661
+ 12.28907824673544
+  6.855905417203194
+  2.756493722442482
+ -2.380074475771338
 
 ```
 
@@ -113,16 +112,16 @@ julia> A[40µs .. 220µs, :c1]
 1-dimensional AxisArray{Float64,1,...} with axes:
     :time, 5.0e-5 s:2.5e-5 s:0.0002 s
 And data, a 7-element Array{Float64,1}:
-  3.42795
-  1.37825
- -1.19004
- -1.99414
-  2.9429
- -0.226449
-  0.821446
+  3.427952708601597
+  1.378246861221241
+ -1.190037237885669
+ -1.994137635575063
+  2.9429034802756004
+ -0.22644919919326786
+  0.8214461136364685
 
 julia> AxisArrays.axes(ans, 1)
-AxisArrays.Axis{:time,StepRangeLen{Quantity{Float64, Dimensions:{𝐓}, Units:{s}},Base.TwicePrecision{Quantity{Float64, Dimensions:{𝐓}, Units:{s}}},Base.TwicePrecision{Quantity{Float64, Dimensions:{𝐓}, Units:{s}}}}}(5.0e-5 s:2.5e-5 s:0.0002 s)
+Axis{:time,StepRangeLen{Unitful.Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}},Base.TwicePrecision{Unitful.Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}}},Base.TwicePrecision{Unitful.Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}}}}}(5.0e-5 s:2.5e-5 s:0.0002 s)
 
 ```
 
@@ -138,7 +137,7 @@ julia> A[2.5e-5s..2.5e-5s, :c1]
 1-dimensional AxisArray{Float64,1,...} with axes:
     :time, 2.5e-5 s:2.5e-5 s:2.5e-5 s
 And data, a 1-element Array{Float64,1}:
- 6.14454
+ 6.14453912336772
 
 ```
 
@@ -147,7 +146,7 @@ You can even index by multiple values by broadcasting `atvalue` over an array:
 ```jldoctest
 julia> A[atvalue.([2.5e-5s, 75.0µs])]
 2-dimensional AxisArray{Float64,2,...} with axes:
-    :time, Quantity{Float64, Dimensions:{𝐓}, Units:{s}}[2.5e-5 s, 7.5e-5 s]
+    :time, Unitful.Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}}[2.5e-5 s, 7.5e-5 s]
     :chan, Symbol[:c1, :c2]
 And data, a 2×2 Array{Float64,2}:
  6.14454  12.2891
@@ -166,13 +165,13 @@ julia> A[atindex(-90µs .. 90µs, 5), :c2]
 1-dimensional AxisArray{Float64,1,...} with axes:
     :time_sub, -7.5e-5 s:2.5e-5 s:7.5e-5 s
 And data, a 7-element Array{Float64,1}:
- 12.2891
-  6.85591
-  2.75649
- -2.38007
- -3.98828
-  5.88581
- -0.452898
+ 12.28907824673544
+  6.855905417203194
+  2.756493722442482
+ -2.380074475771338
+ -3.988275271150126
+  5.885806960551201
+ -0.4528983983865357
 
 ```
 
@@ -187,28 +186,28 @@ julia> idxs = findall(diff(A[:,:c1] .< -15) .> 0);
 julia> spks = A[atindex(-200µs .. 800µs, idxs), :c1]
 2-dimensional AxisArray{Float64,2,...} with axes:
     :time_sub, -0.0002 s:2.5e-5 s:0.0008 s
-    :time_rep, Quantity{Float64, Dimensions:{𝐓}, Units:{s}}[0.162 s, 0.20045 s, 0.28495 s, 0.530325 s, 0.821725 s, 1.0453 s, 1.11967 s, 1.1523 s, 1.22085 s, 1.6253 s  …  57.0094 s, 57.5818 s, 57.8716 s, 57.8806 s, 58.4353 s, 58.7041 s, 59.1015 s, 59.1783 s, 59.425 s, 59.5657 s]
-And data, a 41×247 Array{Float64,2}:
-  -1.82238     2.3315      -1.56147   …    4.33751     4.77713    -1.81713
-   0.672063    7.25649      0.633375       1.54583     5.81194    -4.706
-  -1.65182     2.57487      0.477408       3.09505     3.52478     4.13037
-   4.46035     2.11313      4.78372        1.23385     7.2525      3.57485
-   5.25651    -2.19785      3.05933        0.965021    6.78414     5.94854
-   7.8537      0.345008     0.960533  …    0.812989    0.336715    0.303909
-   0.466816    0.643649    -3.67087        3.92978    -3.1242      0.789722
-  -6.0445    -13.2441      -4.60716        0.265144   -4.50987    -8.84897
-  -9.21703   -13.2254     -14.4409        -8.6664    -13.3457    -11.6213
- -16.1809    -22.7037     -25.023        -15.9376    -28.0817    -16.996
-   ⋮                                  ⋱                ⋮
-   1.72728     4.77428    -10.3922        -2.08555     1.19198    -1.94365
-  -0.301629    0.0683982   -4.36574        1.92362    -5.12333    -3.4431
-   4.7182      1.18615      4.40717       -4.51757    -8.64314     0.0800021
-  -2.43775    -0.151882    -1.40817   …   -3.38555    -2.23418     0.728549
-   3.2482     -0.60967      0.471288       2.53395     0.468817   -3.65905
-  -4.26967     2.24747     -3.13758        1.74967     4.5052     -0.145357
-  -0.752487    1.69446     -1.20491        1.71429     1.81936     0.290158
-   4.64348    -3.94187     -1.59213        7.15428    -0.539748    4.82309
-   1.09652    -2.66999      0.521931  …   -3.80528     1.70421     3.40583
+    :time_rep, Unitful.Quantity{Float64,𝐓,Unitful.FreeUnits{(s,),𝐓,nothing}}[0.161275 s, 0.489925 s, 0.957175 s, 1.1457 s, 1.40185 s, 1.84193 s, 2.07365 s, 2.32947 s, 2.7763 s, 2.79275 s  …  57.6724 s, 57.7152 s, 57.749 s, 58.1109 s, 58.3783 s, 58.4178 s, 58.921 s, 59.1693 s, 59.6546 s, 59.7824 s]
+And data, a 41×273 Array{Float64,2}:
+  -2.47171    -1.72242     4.54491     …    2.74969     3.1869     -2.00435
+   6.78576     3.65903     5.14183         -0.98535     3.96603    -5.74065
+   1.56584     1.88131     0.470257         2.66664     5.27674     0.0610194
+   4.78242     3.20142     3.28502          5.20484    -3.66085     1.16247
+   3.23148    -1.24878    -0.0252124        5.46585     4.88651     3.64283
+   6.5714      0.572557    3.038       …   -0.974689    2.61297     7.3496
+   4.46643    -0.444754   -4.52857          0.304449   -1.54659    -2.53197
+  -9.57806    -1.29114    -2.23969         -9.10793    -6.35711    -5.06038
+ -12.2567     -5.06283    -8.53581        -11.9826    -14.868     -14.0543
+ -24.5458    -19.9823    -20.0798         -20.3065    -18.5437    -25.3609
+   ⋮                                   ⋱    ⋮
+   2.14059    -0.365031    1.36771         -4.23763     5.9211     -3.84708
+   3.58157     2.87076     0.835568        -2.27752     1.18686     2.3412
+   6.7953     -1.32384    -3.0897           0.464151   -1.12327    -2.14844
+   1.19649     2.44709    -5.16029     …   -0.965397    2.37465    -2.36185
+  -1.57253     0.526027    0.831144         0.6505      3.61602     1.93462
+   0.739684   -1.74925    -6.18072         -7.36229    -0.187708    1.97774
+   0.645211    1.04006    -1.33676          4.30262    -4.46544    -0.278097
+   1.32901    -1.74821     1.94781          0.780325    3.22951    -0.436806
+   0.387814    0.128453   -0.00287742  …   -1.51196    -2.10081    -2.26663
 
 ```
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -476,7 +476,7 @@ dropax(ax) = ()
 # A simple display method to include axis information. It might be nice to
 # eventually display the axis labels alongside the data array, but that is
 # much more difficult.
-function summaryio(io::IO, A::AxisArray)
+function Base.summary(io::IO, A::AxisArray)
     _summary(io, A)
     for (name, val) in zip(axisnames(A), axisvalues(A))
         print(io, "    :$name, ")
@@ -486,12 +486,6 @@ function summaryio(io::IO, A::AxisArray)
     print(io, "And data, a ", summary(A.data))
 end
 _summary(io, A::AxisArray{T,N}) where {T,N} = println(io, "$N-dimensional AxisArray{$T,$N,...} with axes:")
-
-function Base.summary(A::AxisArray)
-    io = IOBuffer()
-    summaryio(io, A)
-    String(take!(io))
-end
 
 # Custom methods specific to AxisArrays
 """


### PR DESCRIPTION
The documentation build and doctests currently fail, breaking CI. Fix this:

* Add sitename property now required by Documenter
* Fix use of `Base.summary` so that axis type information is readable again.
* Update doctest outputs to the numbers produced in julia 1.0, and the latest version of Unitful.
* Move forward with docs deploy via julia 1.0