### PR TITLE
Fix iteration over Axis

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -81,8 +81,11 @@ Base.length(A::Axis) = length(A.val)
 (A::Axis{name})(i) where {name} = Axis{name}(i)
 Base.convert(::Type{Axis{name,T}}, ax::Axis{name,T}) where {name,T} = ax
 Base.convert(::Type{Axis{name,T}}, ax::Axis{name}) where {name,T} = Axis{name}(convert(T, ax.val))
-Base.iterate(a::Axis) = (a, nothing)
-Base.iterate(::Axis, ::Any) = nothing
+Base.iterate(A::Axis, i...) = Base.iterate(A.val, i...)
+
+Base.IteratorSize(::Type{<:Axis}) = HasShape{1}()
+Base.IteratorEltype(::Type{<:Axis}) = HasEltype()
+
 Base.iterate(::Type{T}) where {T<:Axis} = (T, nothing)
 Base.iterate(::Type{T}, ::Any) where {T<:Axis} = nothing
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -83,8 +83,8 @@ Base.convert(::Type{Axis{name,T}}, ax::Axis{name,T}) where {name,T} = ax
 Base.convert(::Type{Axis{name,T}}, ax::Axis{name}) where {name,T} = Axis{name}(convert(T, ax.val))
 Base.iterate(A::Axis, i...) = Base.iterate(A.val, i...)
 
-Base.IteratorSize(::Type{<:Axis}) = HasShape{1}()
-Base.IteratorEltype(::Type{<:Axis}) = HasEltype()
+Base.IteratorSize(::Type{<:Axis}) = Base.HasShape{1}()
+Base.IteratorEltype(::Type{<:Axis}) = Base.HasEltype()
 
 Base.iterate(::Type{T}) where {T<:Axis} = (T, nothing)
 Base.iterate(::Type{T}, ::Any) where {T<:Axis} = nothing


### PR DESCRIPTION
Iterate over elements in the Axis instead of just returning the axis. Is in line with `axes(Ax) = OneTo(<length of elems>)` and `length(Ax) = <length of elems>`.

Also add `Iterator{Size,Eltype}` traits.

No tests are broken (that worked before).

Does this make sense?