### PR TITLE
Respect generated function invariants

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -271,13 +271,10 @@ Given an AxisArray and an Axis, return the integer dimension of
 the Axis within the array.
 """
 axisdim(A::AxisArray, ax::Axis) = axisdim(A, typeof(ax))
-@generated function axisdim(A::AxisArray, ax::Type{Ax}) where Ax<:Axis
-    dim = axisdim(A, Ax)
-    :($dim)
-end
+axisdim(A::AxisArray, ax::Type{Ax}) where Ax<:Axis = axisdim(typeof(A), Ax)
 # The actual computation is done in the type domain, which is a little tricky
 # due to type invariance.
-function axisdim(::Type{AxisArray{T,N,D,Ax}}, ::Type{<:Axis{name,S} where S}) where {T,N,D,Ax,name}
+@generated function axisdim(::Type{AxisArray{T,N,D,Ax}}, ::Type{<:Axis{name,S} where S}) where {T,N,D,Ax,name}
     isa(name, Int) && return name <= N ? name : error("axis $name greater than array dimensionality $N")
     names = axisnames(Ax)
     idx = Compat.findfirst(isequal(name), names)

--- a/test/indexing.jl
+++ b/test/indexing.jl
@@ -70,11 +70,11 @@ B = AxisArray(reshape(1:15, 5,3), .1:.1:0.5, [:a, :b, :c])
 @test @view(B[ClosedInterval(0.2,  0.6), :]) == @view(B[ClosedInterval(0.2,  0.6)]) == B[2:end,:]
 
 # Test Categorical indexing
-@test B[:, :a] == @view(B[:, :a]) == B[:,1]
-@test B[:, :c] == @view(B[:, :c]) == B[:,3]
-@test B[:, [:a]] == @view(B[:, [:a]]) == B[:,[1]]
-@test B[:, [:c]] == @view(B[:, [:c]]) == B[:,[3]]
-@test B[:, [:a,:c]] == @view(B[:, [:a,:c]]) == B[:,[1,3]]
+@test @inferred(B[:, :a]) == @view(B[:, :a]) == B[:,1]
+@test @inferred(B[:, :c]) == @view(B[:, :c]) == B[:,3]
+@test @inferred(B[:, [:a]]) == @view(B[:, [:a]]) == B[:,[1]]
+@test @inferred(B[:, [:c]]) == @view(B[:, [:c]]) == B[:,[3]]
+@test @inferred(B[:, [:a,:c]]) == @view(B[:, [:a,:c]]) == B[:,[1,3]]
 
 @test B[Axis{:row}(ClosedInterval(0.15, 0.3))] == @view(B[Axis{:row}(ClosedInterval(0.15, 0.3))]) == B[2:3,:]
 


### PR DESCRIPTION
Generated functions cannot call any function which might have a method
added after the generated function is defined. This means we need to
hoist such functions outside the generator, either by calling them
beforehand (as we do with axistrait), or ensuring that all methods are
defined before the generator (axisdim).

I belive this fixes #161 (test failures with precompiled-modules=no).

### TODO
* [x] Check that the compiler is happy with the way I've hoisted `axistrait()` out of the generated function here.