### PR TITLE
Fix performance bug: ensure `to_index` is inlined

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -328,7 +328,7 @@ _axistraits() = ()
 # indexing types to their integer or integer range equivalents using axisindexes
 # It is separate from the `Base.getindex` function to allow reuse between
 # set- and get- index.
-to_index(A::AxisArray, I...) = _to_index(A, _axistraits(I...), I...)
+@inline to_index(A::AxisArray, I...) = _to_index(A, _axistraits(I...), I...)
 
 @generated function _to_index(A::AxisArray{T,N,D,Ax}, axtraits, I...) where {T,N,D,Ax}
     ex = Expr(:tuple)


### PR DESCRIPTION
I believe this fixes #169 - looks like I needed an extra an `@inline` in #163