### PR TITLE
Add range interface methods to Axis

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -89,6 +89,10 @@ Base.IteratorEltype(::Type{<:Axis}) = Base.HasEltype()
 Base.iterate(::Type{T}) where {T<:Axis} = (T, nothing)
 Base.iterate(::Type{T}, ::Any) where {T<:Axis} = nothing
 
+Base.first(A::Axis) = first(A.val)
+Base.last(A::Axis) = last(A.val)
+Base.step(A::Axis{name,<:AbstractRange}) where {name} = step(A.val)
+
 """
 An AxisArray is an AbstractArray that wraps another AbstractArray and
 adds axis names and values to each array dimension. AxisArrays can be indexed

--- a/test/core.jl
+++ b/test/core.jl
@@ -197,6 +197,9 @@ T = A[AxisArrays.Axis{:x}]
 @test length(Axis{:col}(-1:2)) === 4
 @test AxisArrays.axisname(Axis{:foo}(1:2)) == :foo
 @test AxisArrays.axisname(Axis{:foo})      == :foo
+@test first(Axis{:row}(1:3)) == 1
+@test step(Axis{:row}(1:3)) == 1
+@test last(Axis{:row}(1:3)) == 3
 
 # Test Timetype axis construction
 dt, vals = DateTime(2010, 1, 2, 3, 40), randn(5,2)


### PR DESCRIPTION
This adds `first`, `last`, and `step` to the `Axis` interface. The first two were functional before but called `iterate` and `Axis[end]` instead of directly acting on the `val` field. The last method wasn't possible before and now is.

Note: This PR was made in reference to 
- https://github.com/JuliaArrays/AxisArrays.jl/issues/175
- https://github.com/JuliaImages/ImageCore.jl/issues/112