### PR TITLE
Support IntervalSets 0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AxisArrays"
 uuid = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -9,7 +9,7 @@ IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
 RangeArrays = "b3c3ace0-ae52-54e7-9d0b-2c1406fd6b9d"
 
 [compat]
-IntervalSets = "0.1, 0.2, 0.3, 0.4"
+IntervalSets = "0.1, 0.2, 0.3, 0.4, 0.5"
 IterTools = "1"
 RangeArrays = "0.3"
 julia = "1"


### PR DESCRIPTION
AxisArrays does not support the latest version of IntervalSets (noticed this due to some issues in Turing, see https://github.com/TuringLang/Turing.jl/issues/683#issuecomment-616412903 and https://github.com/TuringLang/Turing.jl/issues/1220). Maybe it would be a good idea to add CompatHelper?