### PR TITLE
Implement mapslices for AxisArrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.mem
 docs/build
 docs/site
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AxisArrays"
 uuid = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/core.jl
+++ b/src/core.jl
@@ -427,6 +427,31 @@ function Base.map(f, As::AxisArray{T,N,D,Ax}...) where {T,N,D,Ax<:Tuple{Vararg{A
     return AxisArray(map(f, data...), As[1].axes...)
 end
 
+function Base.mapslices(f, A::AxisArray; dims)
+    new_axes = Axis[axes(A)...]
+
+    if (dims isa Integer || dims isa Vector{<:Integer})
+        for i in dims
+            ax = axes(A)[i]
+            new_axes[i] = ax(Base.OneTo(1))
+        end
+
+        return AxisArray(mapslices(f, A.data; dims=dims), new_axes...)
+    else
+        if (dims isa Axis || dims isa Type{<:Axis})
+            dims = [dims]
+        end
+
+        for ax in dims
+            i = axisdim(A, ax)
+            new_axes[i] = ax(Base.OneTo(1))
+        end
+
+        int_dims = axisdim.(Ref(A), dims)
+        return AxisArray(mapslices(f, A.data; dims=int_dims), new_axes...)
+    end
+end
+
 permutation(to::Union{AbstractVector{Int},Tuple{Int,Vararg{Int}}}, from::Symbols) = to
 
 """

--- a/src/core.jl
+++ b/src/core.jl
@@ -438,12 +438,11 @@ function Base.mapslices(f, A::AxisArray; dims)
     result = mapslices(f, A.data; dims=int_dims)
 
     new_axes = Vector{Axis}(collect(axes(A)))  # ensure mutable
-    for i in int_dims
-        n = axisnames(A)[i]
-        # if Axis has changed length replace with default axis values
-        if size(result, i) !== size(A, i)
-            new_axes[i] = Axis{n}(Base.OneTo(size(result, i)))
-        end
+    # if Axis has changed length replace with default Base.OneTo(n)
+    replace!(new_axes) do ax
+        i = axisdim(A, ax)
+        n = size(result, i)
+        return n == length(ax) ? ax : ax(Base.OneTo(n))
     end
 
     return AxisArray(result, new_axes...)

--- a/src/core.jl
+++ b/src/core.jl
@@ -281,14 +281,11 @@ axisname(::Union{Type{<:Axis{name}},Axis{name}}) where {name} = name
     axisdim(::AxisArray, ::Integer) -> Int
 
 Given an AxisArray and an Axis (or integer), return the integer dimension of
-the Axis within the array if it exists.
+the Axis within the array.
 """
 axisdim(A::AxisArray, ax::Axis) = axisdim(A, typeof(ax))
 axisdim(A::AxisArray, ax::Type{Ax}) where Ax<:Axis = axisdim(typeof(A), Ax)
-function axisdim(::AxisArray{T,N,D,Ax}, i::Integer) where {T, N, D, Ax}
-    i <= N && return i
-    error("axis $i exceeds array dimension $N")
-end
+axisdim(::AxisArray, i::Integer) = i
 
 # The actual computation is done in the type domain, which is a little tricky
 # due to type invariance.

--- a/src/core.jl
+++ b/src/core.jl
@@ -431,7 +431,7 @@ function Base.map(f, As::AxisArray{T,N,D,Ax}...) where {T,N,D,Ax<:Tuple{Vararg{A
 end
 
 function Base.mapslices(f, A::AxisArray; dims)
-    new_axes = collect(axes(A))  # ensure mutable
+    new_axes = Vector{Axis}(collect(axes(A)))  # ensure mutable
 
     dims =  dims isa Union{AbstractVector, Tuple} ? dims : [dims]
 

--- a/test/core.jl
+++ b/test/core.jl
@@ -306,7 +306,7 @@ for C in arrays
     end
 end
 
-A = AxisArray(collect(reshape(1:15,3,5)), y=["a", "b", "c"], x=[1, 2, 3, 4, 5])
+A = AxisArray(reshape(1:15,3,5), y=["a", "b", "c"], x=[1, 2, 3, 4, 5])
 expected1 = AxisArray([6 15 24 33 42], y=Base.OneTo(1), x=[1, 2, 3, 4, 5])
 expected2 = AxisArray([35, 40, 45][:, :], y=["a", "b", "c"], x=Base.OneTo(1))
 expected12 = AxisArray([120][:, :], :y, :x)
@@ -323,8 +323,11 @@ expected12 = AxisArray([120][:, :], :y, :x)
 @test mapslices(sum, A; dims=Axis{:x}()) == expected2
 @test mapslices(sum, A; dims=[Axis{:y}(), Axis{:x}()]) == expected12
 
-@test mapslices(sum, A; dims=[]) == A
+A = AxisArray(reshape(1:15,3,5), Axis{:y}(range(0.1, length=3)), Axis{:x}(range(0.1, length=5)))
+@test mapslices(sum, A; dims=1) == expected1
+@test mapslices(sum, A; dims=2) == expected2
 
+@test mapslices(sum, A; dims=[]) == A
 
 function typeof_noaxis(::AxisArray{T,N,D}) where {T,N,D}
     AxisArray{T,N,D}

--- a/test/core.jl
+++ b/test/core.jl
@@ -306,6 +306,26 @@ for C in arrays
     end
 end
 
+A = AxisArray(collect(reshape(1:15,3,5)), y=["a", "b", "c"], x=[1, 2, 3, 4, 5])
+expected1 = AxisArray([6 15 24 33 42], y=Base.OneTo(1), x=[1, 2, 3, 4, 5])
+expected2 = AxisArray([35, 40, 45][:, :], y=["a", "b", "c"], x=Base.OneTo(1))
+expected12 = AxisArray([120][:, :], :y, :x)
+
+@test mapslices(sum, A; dims=1) == expected1
+@test mapslices(sum, A; dims=2) == expected2
+@test mapslices(sum, A; dims=[1, 2]) == expected12
+
+@test mapslices(sum, A; dims=Axis{:y}) == expected1
+@test mapslices(sum, A; dims=Axis{:x}) == expected2
+@test mapslices(sum, A; dims=[Axis{:y}, Axis{:x}]) == expected12
+
+@test mapslices(sum, A; dims=Axis{:y}()) == expected1
+@test mapslices(sum, A; dims=Axis{:x}()) == expected2
+@test mapslices(sum, A; dims=[Axis{:y}(), Axis{:x}()]) == expected12
+
+@test mapslices(sum, A; dims=[]) == A
+
+
 function typeof_noaxis(::AxisArray{T,N,D}) where {T,N,D}
     AxisArray{T,N,D}
 end

--- a/test/core.jl
+++ b/test/core.jl
@@ -336,7 +336,7 @@ expected = AxisArray([335 370 405; 370 410 450; 405 450 495], Axis{:y}(range(0.1
 
 # operation preserving original array size
 A = AxisArray(reshape(1:15,3,5), Axis{:y}(range(0.1, length=3)), Axis{:x}(range(0.1, length=5)))
-expected = AxisArray(fill(1,3,5), axes(A))
+expected = AxisArray(fill(1,3,5), AxisArrays.axes(A))
 @test mapslices(x->fill(1, 3), A, dims=1) == expected
 @test mapslices(x->fill(1, 5), A, dims=2) == expected
 @test mapslices(x->fill(1, 3, 5), A, dims=(1, 2)) == expected

--- a/test/core.jl
+++ b/test/core.jl
@@ -172,7 +172,6 @@ A = @inferred(AxisArray(reshape(1:24, 2,3,4),
 @test axisdim(A, Axis{:x}) == axisdim(A, Axis{:x}()) == axisdim(A, 1) == 1
 @test axisdim(A, Axis{:y}) == axisdim(A, Axis{:y}()) == axisdim(A, 2) == 2
 @test axisdim(A, Axis{:z}) == axisdim(A, Axis{:z}()) == axisdim(A, 3) == 3
-@test_throws ErrorException axisdim(A, 4)
 # Test axes
 @test @inferred(AxisArrays.axes(A)) == (Axis{:x}(.1:.1:.2), Axis{:y}(1//10:1//10:3//10), Axis{:z}(["a", "b", "c", "d"]))
 @test @inferred(AxisArrays.axes(A, Axis{:x})) == @inferred(AxisArrays.axes(A, Axis{:x}())) == Axis{:x}(.1:.1:.2)

--- a/test/core.jl
+++ b/test/core.jl
@@ -169,9 +169,10 @@ A = @inferred(AxisArray(reshape(1:24, 2,3,4),
 @inferred AxisArray(A, (Axis{:yoyo}(1:length(A[Axis{:x}])),))
 
 # Test axisdim
-@test axisdim(A, Axis{:x}) == axisdim(A, Axis{:x}()) == 1
-@test axisdim(A, Axis{:y}) == axisdim(A, Axis{:y}()) == 2
-@test axisdim(A, Axis{:z}) == axisdim(A, Axis{:z}()) == 3
+@test axisdim(A, Axis{:x}) == axisdim(A, Axis{:x}()) == axisdim(A, 1) == 1
+@test axisdim(A, Axis{:y}) == axisdim(A, Axis{:y}()) == axisdim(A, 2) == 2
+@test axisdim(A, Axis{:z}) == axisdim(A, Axis{:z}()) == axisdim(A, 3) == 3
+@test_throws ErrorException axisdim(A, 4)
 # Test axes
 @test @inferred(AxisArrays.axes(A)) == (Axis{:x}(.1:.1:.2), Axis{:y}(1//10:1//10:3//10), Axis{:z}(["a", "b", "c", "d"]))
 @test @inferred(AxisArrays.axes(A, Axis{:x})) == @inferred(AxisArrays.axes(A, Axis{:x}())) == Axis{:x}(.1:.1:.2)


### PR DESCRIPTION
Closes #193, replacing #194 as it now accepts integer and Axis dims arguments

```julia
julia> A = AxisArray(collect(reshape(1:15,3,5)), :y, :x)
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, Base.OneTo(3)
    :x, Base.OneTo(5)
And data, a 3×5 Array{Int64,2}:
 1  4  7  10  13
 2  5  8  11  14
 3  6  9  12  15

julia> mapslices(sum, A; dims=1)
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, Base.OneTo(1)
    :x, Base.OneTo(5)
And data, a 1×5 Array{Int64,2}:
 6  15  24  33  42

julia> mapslices(sum, A; dims=Axis{:y})
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, Base.OneTo(1)
    :x, Base.OneTo(5)
And data, a 1×5 Array{Int64,2}:
 6  15  24  33  42

julia> mapslices(sum, A; dims=Axis{:y}())
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, Base.OneTo(1)
    :x, Base.OneTo(5)
And data, a 1×5 Array{Int64,2}:
 6  15  24  33  42

julia> mapslices(sum, A; dims=[Axis{:y}, Axis{:x}])
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, Base.OneTo(1)
    :x, Base.OneTo(1)
And data, a 1×1 Array{Int64,2}:
 120
```


EDIT: and can also replace non-integer axis values
```julia
julia> A_non_int = AxisArray(reshape(1:15,3,5), Axis{:y}(range(0.1, length=3)), Axis{:x}(range(0.1, length=5)))
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, 0.1:1.0:2.1
    :x, 0.1:1.0:4.1
And data, a 3×5 reshape(::UnitRange{Int64}, 3, 5) with eltype Int64:
 1  4  7  10  13
 2  5  8  11  14
 3  6  9  12  15

julia> mapslices(sum, A; dims=Axis{:x})
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, 0.1:1.0:2.1
    :x, Base.OneTo(1)
And data, a 3×1 Array{Int64,2}:
 35
 40
 45
```

and non-reducing operations
```julia
julia> mapslices(x->x*x', A; dims=(1, 2))
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, 0.1:1.0:2.1
    :x, Base.OneTo(3)
And data, a 3×3 Array{Int64,2}:
 335  370  405
 370  410  450
 405  450  495
```

I will note that when `mapslices` changes the length of an `Axis` (as in the non-reducing example) it's not possible to know what the new axis values will be so substituting the default axis values `Base.OneTo(n)` seemed appropriate.

Another example might be:
```julia
julia> mapslices(x->fill(1, 7), A; dims=1)
2-dimensional AxisArray{Int64,2,...} with axes:
    :y, Base.OneTo(7)
    :x, 0.1:1.0:4.1
And data, a 7×5 Array{Int64,2}:
 1  1  1  1  1
 1  1  1  1  1
 1  1  1  1  1
 1  1  1  1  1
 1  1  1  1  1
 1  1  1  1  1
 1  1  1  1  1
```