### PR TITLE
extend `OffsetArrays.centered` for AxisArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,12 +6,14 @@ version = "0.4.4"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 IterTools = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 RangeArrays = "b3c3ace0-ae52-54e7-9d0b-2c1406fd6b9d"
 
 [compat]
 IntervalSets = "0.1, 0.2, 0.3, 0.4, 0.5"
 IterTools = "1"
 RangeArrays = "0.3"
+OffsetArrays = "1"
 julia = "1"
 
 [extras]

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -7,6 +7,7 @@ import Base.Iterators: repeated
 using RangeArrays, IntervalSets
 using IterTools
 using Dates
+using OffsetArrays
 
 function axes end
 
@@ -22,5 +23,7 @@ include("indexing.jl")
 include("sortedvector.jl")
 include("categoricalvector.jl")
 include("combine.jl")
+
+include("offsetarrays.jl") # extend OffsetArrays
 
 end

--- a/src/AxisArrays.jl
+++ b/src/AxisArrays.jl
@@ -24,6 +24,7 @@ include("sortedvector.jl")
 include("categoricalvector.jl")
 include("combine.jl")
 
+# TODO: make this conditional when https://github.com/JuliaLang/Pkg.jl/issues/1285 is supported
 include("offsetarrays.jl") # extend OffsetArrays
 
 end

--- a/src/offsetarrays.jl
+++ b/src/offsetarrays.jl
@@ -1,0 +1,6 @@
+if isdefined(OffsetArrays, :centered)
+    # Compat for OffsetArrays v1.9
+    # https://github.com/JuliaArrays/OffsetArrays.jl/pull/242
+    OffsetArrays.centered(ax::Axis{name}) where name = Axis{name}(OffsetArrays.centered(ax.val))
+    OffsetArrays.centered(a::AxisArray) = AxisArray(OffsetArrays.centered(a.data), OffsetArrays.centered.(AxisArrays.axes(a)))
+end

--- a/test/offsetarrays.jl
+++ b/test/offsetarrays.jl
@@ -1,0 +1,22 @@
+if isdefined(OffsetArrays, :centered)
+    # only test this if we're using OffsetArrays at least v1.9
+    @testset "centered" begin
+        check_range(r, f, l) = (@test first(r) == f; @test last(r) == l)
+        check_range_axes(r, f, l) = check_range(Base.axes(r)[1], f, l)
+
+        check_range(Base.axes(OffsetArrays.centered(1:3))[1], -1, 1)
+        a = AxisArray(rand(3, 3), Axis{:y}(0.1:0.1:0.3), Axis{:x}(1:3))
+
+        ca = OffsetArrays.centered(a)
+        axs = Base.axes(ca)
+        check_range(axs[1], -1, 1)
+        check_range(axs[2], -1, 1)
+        @test ca[OffsetArrays.center(ca)...] == a[OffsetArrays.center(a)...]
+
+        axs = AxisArrays.axes(ca)
+        check_range(axs[1].val, 0.1, 0.3)
+        check_range(axs[2].val, 1, 3)
+        check_range_axes(axs[1].val, -1, 1)
+        check_range_axes(axs[1].val, -1, 1)
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using AxisArrays
 using Dates
 using Test
 using Random
+using OffsetArrays
 import IterTools
 
 @testset "AxisArrays" begin
@@ -37,5 +38,9 @@ import IterTools
 
     @testset "README" begin
         include("readme.jl")
+    end
+
+    @testset "OffsetArrays" begin
+        include("offsetarrays.jl")
     end
 end


### PR DESCRIPTION
`ImageFiltering.centered` is now moved to `OffsetArrays.centered` (https://github.com/JuliaArrays/OffsetArrays.jl/issues/169), this requires `AxisArrays.jl` to extend its method so that `ImageFiltering` is still working as usual.

The codes here originally live in https://github.com/JuliaImages/ImageFiltering.jl/blob/d4df16a6a130fa0f1573394172bb48e634b6e76a/src/ImageFiltering.jl#L96-L99

This change adds `OffsetArrays` as a dependency:

```julia
julia> @time using AxisArrays
# after: 0.252187 seconds (408.84 k allocations: 25.418 MiB, 3.28% gc time)
# before:  0.209274 seconds (329.24 k allocations: 19.370 MiB)
```

I do not have write permission to this repo so may need someone with write permission to review it. Or I could help do some regular maintenance on this package. cc: @mbauman @timholy 